### PR TITLE
Save only annotations in snippet to database

### DIFF
--- a/client/src/store/annotations.ts
+++ b/client/src/store/annotations.ts
@@ -163,6 +163,28 @@ export function useAnnotationStore() {
     return { firstCharacter, lastCharacter, firstIndex, lastIndex };
   }
 
+  // TODO: Shouldnt this be in another file (Editor.vue, editor store etc.) or maybe even in the backend?
+  // TODO: This should be more advanced to create a real changeset (annotated characters, updated information etc.)
+  /**
+   * Retrieves the annotations that need to be saved to the database. This includes annotations connected to
+   * at least one character in the snippet as well as annotations marked as deleted.
+   *
+   * @returns {Annotation[]} An array of annotations to be saved.
+   */
+  function getAnnotationsToSave(): Annotation[] {
+    let charUuids: Set<string> = new Set();
+
+    snippetCharacters.value.forEach(c => {
+      c.annotations.forEach(a => charUuids.add(a.uuid));
+    });
+
+    const affectedAnnotations: Annotation[] = annotations.value.filter((annotation: Annotation) => {
+      return charUuids.has(annotation.data.properties.uuid) || annotation.status === 'deleted';
+    });
+
+    return affectedAnnotations;
+  }
+
   /**
    * Resets all annotation-related state variables to their initial values. Called when the Editor component is unmounted.
    *
@@ -338,6 +360,7 @@ export function useAnnotationStore() {
     deleteAnnotation,
     expandAnnotation,
     getAnnotationInfo,
+    getAnnotationsToSave,
     initializeAnnotations,
     resetAnnotations,
     shiftAnnotationLeft,

--- a/client/src/views/Editor.vue
+++ b/client/src/views/Editor.vue
@@ -18,9 +18,9 @@ import EditorFilter from '../components/EditorFilter.vue';
 import EditorResizer from '../components/EditorResizer.vue';
 import EditorMetadata from '../components/EditorMetadata.vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
-import { buildFetchUrl, cloneDeep } from '../utils/helper/helper';
+import { areObjectsEqual, areSetsEqual, buildFetchUrl, cloneDeep } from '../utils/helper/helper';
 import ICollection from '../models/ICollection';
-import { AnnotationData, Character, CharacterPostData } from '../models/types';
+import { Annotation, AnnotationData, Character, CharacterPostData } from '../models/types';
 import { IGuidelines } from '../models/IGuidelines';
 import { useAnnotationStore } from '../store/annotations';
 import { useEditorStore } from '../store/editor';
@@ -93,6 +93,7 @@ const {
   annotations,
   initialAnnotations,
   initializeAnnotations,
+  getAnnotationsToSave,
   resetAnnotations,
   updateAnnotationsBeforeSave,
   updateAnnotationStatuses,
@@ -270,6 +271,9 @@ async function saveCharacters(): Promise<void> {
 async function saveAnnotations(): Promise<void> {
   updateAnnotationsBeforeSave();
 
+  // Reduce amount of data that need to sent to the backend
+  const annotationsToSave: Annotation[] = getAnnotationsToSave();
+
   const url: string = buildFetchUrl(`/api/collections/${uuid}/annotations`);
 
   const response: Response = await fetch(url, {
@@ -280,7 +284,7 @@ async function saveAnnotations(): Promise<void> {
       'Content-Type': 'application/json',
     },
     referrerPolicy: 'no-referrer',
-    body: JSON.stringify(annotations.value),
+    body: JSON.stringify(annotationsToSave),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
Instead of sending all annotations of the text to the backend, send only those that were affected by the changes in the current snippet. This reduces the load for backend/database and speeds up the saving process.