### PR TITLE
Allow annotation properties to be annotated in new Editor instance

### DIFF
--- a/client/src/components/EditorAnnotationButton.vue
+++ b/client/src/components/EditorAnnotationButton.vue
@@ -322,7 +322,9 @@ function createNewAnnotation(
   const newAnnotationNormdata = Object.fromEntries(normdataCategories.map(m => [m, []]));
 
   // Additional texts (= connected Collection->Text nodes). Not existing when created, but needed in Annotation structure -> null
-  const additionalTexts = Object.fromEntries(config.additionalTexts.map(t => [t.name, null]));
+  const additionalTexts = Object.fromEntries(
+    (config.additionalTexts ?? []).map(t => [t.name, null]),
+  );
 
   const newAnnotation: Annotation = {
     characterUuids: characters.map((char: Character) => char.data.uuid),

--- a/client/src/components/EditorAnnotationButton.vue
+++ b/client/src/components/EditorAnnotationButton.vue
@@ -12,6 +12,7 @@ import { useToast } from 'primevue/usetoast';
 import AnnotationRangeError from '../utils/errors/annotationRange.error';
 import { Annotation, AnnotationProperty, AnnotationType, Character } from '../models/types';
 import IAnnotation from '../models/IAnnotation';
+import IText from '../models/IText';
 import Button from 'primevue/button';
 import SplitButton from 'primevue/splitbutton';
 import { ToastServiceMethods } from 'primevue/toastservice';
@@ -319,11 +320,22 @@ function createNewAnnotation(
   // Normdata (= connected nodes). Empty when created, but needed in Annotation structure -> empty arrays
   const normdataCategories: string[] = guidelines.value.annotations.resources.map(r => r.category);
   const newAnnotationNormdata = Object.fromEntries(normdataCategories.map(m => [m, []]));
+  const additionalText: IText | null = config.hasAdditionalText
+    ? { text: '', uuid: crypto.randomUUID() }
+    : null;
 
   const newAnnotation: Annotation = {
     characterUuids: characters.map((char: Character) => char.data.uuid),
-    data: { properties: newAnnotationData, normdata: newAnnotationNormdata },
-    initialData: { properties: newAnnotationData, normdata: newAnnotationNormdata },
+    data: {
+      properties: newAnnotationData,
+      normdata: newAnnotationNormdata,
+      additionalText: additionalText,
+    },
+    initialData: {
+      properties: newAnnotationData,
+      normdata: newAnnotationNormdata,
+      additionalText: additionalText,
+    },
     isTruncated: false,
     startUuid: characters[0].data.uuid,
     endUuid: characters[characters.length - 1].data.uuid,

--- a/client/src/components/EditorAnnotationButton.vue
+++ b/client/src/components/EditorAnnotationButton.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { useCharactersStore } from '../store/characters';
 import { useAnnotationStore } from '../store/annotations';
-import { getParentCharacterSpan, getSelectionData, isEditorElement } from '../utils/helper/helper';
+import {
+  cloneDeep,
+  getParentCharacterSpan,
+  getSelectionData,
+  isEditorElement,
+} from '../utils/helper/helper';
 import iconsMap from '../utils/helper/icons';
 import { useGuidelinesStore } from '../store/guidelines';
 import { useFilterStore } from '../store/filter';
@@ -329,14 +334,14 @@ function createNewAnnotation(
   const newAnnotation: Annotation = {
     characterUuids: characters.map((char: Character) => char.data.uuid),
     data: {
-      properties: newAnnotationData,
-      normdata: newAnnotationNormdata,
-      additionalTexts: additionalTexts,
+      properties: cloneDeep(newAnnotationData),
+      normdata: cloneDeep(newAnnotationNormdata),
+      additionalTexts: cloneDeep(additionalTexts),
     },
     initialData: {
-      properties: newAnnotationData,
-      normdata: newAnnotationNormdata,
-      additionalTexts: additionalTexts,
+      properties: cloneDeep(newAnnotationData),
+      normdata: cloneDeep(newAnnotationNormdata),
+      additionalTexts: cloneDeep(additionalTexts),
     },
     isTruncated: false,
     startUuid: characters[0].data.uuid,

--- a/client/src/components/EditorAnnotationButton.vue
+++ b/client/src/components/EditorAnnotationButton.vue
@@ -317,14 +317,12 @@ function createNewAnnotation(
     newAnnotationData.subtype = subtype ?? newAnnotationData.subtype;
   }
 
-  // Normdata (= connected nodes). Empty when created, but needed in Annotation structure -> empty arrays
+  // Normdata (= connected Entity nodes). Empty when created, but needed in Annotation structure -> empty arrays
   const normdataCategories: string[] = guidelines.value.annotations.resources.map(r => r.category);
   const newAnnotationNormdata = Object.fromEntries(normdataCategories.map(m => [m, []]));
 
   // Additional texts (= connected Collection->Text nodes). Not existing when created, but needed in Annotation structure -> null
-  const additionalTexts = Object.fromEntries(
-    guidelines.value.annotations.additionalTexts.map(t => [t.name, null]),
-  );
+  const additionalTexts = Object.fromEntries(config.additionalTexts.map(t => [t.name, null]));
 
   const newAnnotation: Annotation = {
     characterUuids: characters.map((char: Character) => char.data.uuid),

--- a/client/src/components/EditorAnnotationButton.vue
+++ b/client/src/components/EditorAnnotationButton.vue
@@ -15,9 +15,14 @@ import { useEditorStore } from '../store/editor';
 import { useShortcutsStore } from '../store/shortcuts';
 import { useToast } from 'primevue/usetoast';
 import AnnotationRangeError from '../utils/errors/annotationRange.error';
-import { Annotation, AnnotationProperty, AnnotationType, Character } from '../models/types';
+import {
+  AdditionalText,
+  Annotation,
+  AnnotationProperty,
+  AnnotationType,
+  Character,
+} from '../models/types';
 import IAnnotation from '../models/IAnnotation';
-import IText from '../models/IText';
 import Button from 'primevue/button';
 import SplitButton from 'primevue/splitbutton';
 import { ToastServiceMethods } from 'primevue/toastservice';
@@ -326,10 +331,8 @@ function createNewAnnotation(
   const normdataCategories: string[] = guidelines.value.annotations.resources.map(r => r.category);
   const newAnnotationNormdata = Object.fromEntries(normdataCategories.map(m => [m, []]));
 
-  // Additional texts (= connected Collection->Text nodes). Not existing when created, but needed in Annotation structure -> null
-  const additionalTexts = Object.fromEntries(
-    (config.additionalTexts ?? []).map(t => [t.name, null]),
-  );
+  // Additional texts (= connected Collection->Text nodes). Empty when created, but needed in Annotation structure -> empty arrays
+  const additionalTexts: AdditionalText[] = [];
 
   const newAnnotation: Annotation = {
     characterUuids: characters.map((char: Character) => char.data.uuid),

--- a/client/src/components/EditorAnnotationButton.vue
+++ b/client/src/components/EditorAnnotationButton.vue
@@ -320,21 +320,23 @@ function createNewAnnotation(
   // Normdata (= connected nodes). Empty when created, but needed in Annotation structure -> empty arrays
   const normdataCategories: string[] = guidelines.value.annotations.resources.map(r => r.category);
   const newAnnotationNormdata = Object.fromEntries(normdataCategories.map(m => [m, []]));
-  const additionalText: IText | null = config.hasAdditionalText
-    ? { text: '', uuid: crypto.randomUUID() }
-    : null;
+
+  // Additional texts (= connected Collection->Text nodes). Not existing when created, but needed in Annotation structure -> null
+  const additionalTexts = Object.fromEntries(
+    guidelines.value.annotations.additionalTexts.map(t => [t.name, null]),
+  );
 
   const newAnnotation: Annotation = {
     characterUuids: characters.map((char: Character) => char.data.uuid),
     data: {
       properties: newAnnotationData,
       normdata: newAnnotationNormdata,
-      additionalText: additionalText,
+      additionalTexts: additionalTexts,
     },
     initialData: {
       properties: newAnnotationData,
       normdata: newAnnotationNormdata,
-      additionalText: additionalText,
+      additionalTexts: additionalTexts,
     },
     isTruncated: false,
     startUuid: characters[0].data.uuid,

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -434,18 +434,18 @@ function setRangeAnchorAtEnd(): void {
       <template #toggleicon>
         <span :class="`pi pi-chevron-${additionalTextIsCollapsed ? 'down' : 'up'}`"></span>
       </template>
-      <RouterLink to="/">
+      <a :href="`/texts/${annotation.data.additionalText.uuid}`" target="_blank">
         <Card>
           <template #content>
             <div class="flex align-items-center gap-4">
               <span class="pi pi-external-link"></span>
               <span>
-                {{ annotation.data.additionalText.text }}
+                {{ annotation.data.additionalText?.text }}
               </span>
             </div>
           </template>
         </Card>
-      </RouterLink>
+      </a>
     </Fieldset>
     <div class="edit-buttons flex justify-content-center">
       <Button

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -13,6 +13,7 @@ import {
 import iconsMap from '../utils/helper/icons';
 import AutoComplete from 'primevue/autocomplete';
 import Button from 'primevue/button';
+import Card from 'primevue/card';
 import ConfirmPopup from 'primevue/confirmpopup';
 import InputText from 'primevue/inputtext';
 import Fieldset from 'primevue/fieldset';
@@ -64,6 +65,7 @@ const fields: AnnotationProperty[] = getAnnotationFields(annotation.data.propert
 
 const propertiesAreCollapsed = ref<boolean>(false);
 const normdataAreCollapsed = ref<boolean>(false);
+const additionalTextIsCollapsed = ref<boolean>(false);
 const normdataCategories: string[] = guidelines.value.annotations.resources.map(r => r.category);
 
 const normdataSearchObject = ref<NormdataSearchObject>(
@@ -81,6 +83,8 @@ const normdataSearchObject = ref<NormdataSearchObject>(
     return object;
   }, {}),
 );
+
+console.log(config.hasAdditionalText);
 
 /**
  * Adds a normdata item to the specified category in the annotation's data.
@@ -420,6 +424,28 @@ function setRangeAnchorAtEnd(): void {
           </template>
         </AutoComplete>
       </div>
+    </Fieldset>
+    <Fieldset
+      v-if="config.hasAdditionalText === true"
+      legend="Additional text"
+      :toggleable="true"
+      @toggle="additionalTextIsCollapsed = !additionalTextIsCollapsed"
+    >
+      <template #toggleicon>
+        <span :class="`pi pi-chevron-${additionalTextIsCollapsed ? 'down' : 'up'}`"></span>
+      </template>
+      <RouterLink to="/">
+        <Card>
+          <template #content>
+            <div class="flex align-items-center gap-4">
+              <span class="pi pi-external-link"></span>
+              <span>
+                {{ annotation.data.additionalText.text }}
+              </span>
+            </div>
+          </template>
+        </Card>
+      </RouterLink>
     </Fieldset>
     <div class="edit-buttons flex justify-content-center">
       <Button

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -53,6 +53,7 @@ interface NormdataSearchObject {
  */
 interface AdditionalTextInputObject {
   availableLabels: string[];
+  inputElm: Ref<HTMLInputElement>;
   inputLabel: string;
   inputText: string;
   mode: 'edit' | 'view';
@@ -107,6 +108,7 @@ const additionalTextInputObject = ref<AdditionalTextInputObject>({
   availableLabels: guidelines.value.annotations.additionalTexts,
   inputLabel: guidelines.value.annotations.additionalTexts[0],
   mode: 'view',
+  inputElm: templateRef('additional-text-input'),
 });
 
 // Used for toggling additional text preview mode. Bit hacky for now, but works.
@@ -647,28 +649,39 @@ function handleDeleteAdditionalText(collectionUuid: string): void {
           :disabled="annotation.isTruncated"
           @click="changeAdditionalTextSelectionMode('edit')"
         />
-        <InputGroup v-show="additionalTextInputObject.mode === 'edit'">
-          <Select
-            v-model="additionalTextInputObject.inputLabel"
-            :options="additionalTextInputObject.availableLabels"
-            placeholder="Choose a label"
-          />
-          <InputText v-model="additionalTextInputObject.inputText" placeholder="Enter text" />
-          <Button
-            icon="pi pi-check"
-            severity="secondary"
-            size="small"
-            title="Add new text"
-            @click="addAdditionalText"
-          />
-          <Button
-            icon="pi pi-times"
-            severity="secondary"
-            size="small"
-            title="Cancel"
-            @click="cancelAdditionalTextOperation"
-          />
-        </InputGroup>
+        <form
+          v-show="additionalTextInputObject.mode === 'edit'"
+          @submit.prevent="addAdditionalText"
+        >
+          <InputGroup>
+            <Select
+              v-model="additionalTextInputObject.inputLabel"
+              :options="additionalTextInputObject.availableLabels"
+              placeholder="Choose a label"
+            />
+            <InputText
+              ref="additional-text-input"
+              required
+              v-model="additionalTextInputObject.inputText"
+              placeholder="Enter text"
+            />
+            <Button
+              type="submit"
+              icon="pi pi-check"
+              severity="secondary"
+              size="small"
+              title="Add new text"
+            />
+            <Button
+              type="button"
+              icon="pi pi-times"
+              severity="secondary"
+              size="small"
+              title="Cancel"
+              @click="cancelAdditionalTextOperation"
+            />
+          </InputGroup>
+        </form>
       </div>
     </Fieldset>
     <div class="edit-buttons flex justify-content-center">

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -22,7 +22,12 @@ import Tag from 'primevue/tag';
 import Select from 'primevue/select';
 import Textarea from 'primevue/textarea';
 import { useConfirm } from 'primevue/useconfirm';
-import { Annotation, AnnotationProperty, AnnotationType } from '../models/types';
+import {
+  Annotation,
+  AnnotationProperty,
+  AnnotationType,
+  CollectionProperty,
+} from '../models/types';
 import IEntity from '../models/IEntity';
 import InputGroup from 'primevue/inputgroup';
 import ICollection from '../models/ICollection';
@@ -306,10 +311,26 @@ function setRangeAnchorAtEnd(): void {
 }
 
 function addAdditionalText(): void {
+  // TODO: This should be dynamic since the key is not always 'comment'.
+  const fields = guidelines.value.collections['comment'].properties;
+  const newCollectionProperties: ICollection = {} as ICollection;
+
+  fields.forEach((field: CollectionProperty) => {
+    // TODO: Is this needed? Or should Collection Properties always be text?
+    switch (field.type) {
+      case 'text':
+        newCollectionProperties[field.name] = '';
+        break;
+      default:
+        newCollectionProperties[field.name] = '';
+    }
+  });
+
   annotation.data.additionalTexts.push({
     nodeLabel: additionalTextInputObject.value.inputLabel,
     data: {
       collection: {
+        ...newCollectionProperties,
         uuid: crypto.randomUUID(),
         label: `${additionalTextInputObject.value.inputLabel} for annotation ${annotation.data.properties.uuid}`,
       } as ICollection,

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -150,27 +150,22 @@ function addNormdataItem(item: NormdataEntry, category: string): void {
 function changeAdditionalTextSelectionMode(mode: 'view' | 'edit'): void {
   additionalTextInputObject.value.mode = mode;
 
-  // if (mode === 'view') {
-
-  //   return;
-  // }
+  if (mode === 'view') {
+    return;
+  }
 
   // // Wait for DOM to update before trying to focus the element
-  // nextTick(() => {
-  //   // TODO: A bit hacky, replace this when upgraded to Vue 3.5?
-  //   // The normdataSearchObject's "elm" property is an one-entry-array with the referenced primevue components
-  //   // that holds the component. Is an array because since the refs are set in a loop in the template
-  //   const elm = normdataSearchObject.value[category].elm[0];
+  nextTick(() => {
+    // TODO: A bit hacky, replace this when upgraded to Vue 3.5?
+    const inputElm: HTMLInputElement | null = additionalTextInputObject.value.inputElm.$el;
 
-  //   if (!elm) {
-  //     console.warn(`Focus failed: Element not found for category "${category}"`);
-  //     return;
-  //   }
+    if (!inputElm) {
+      console.warn('Focus failed: Element not found');
+      return;
+    }
 
-  //   const inputElement: HTMLInputElement = elm.$el?.querySelector('input');
-
-  //   inputElement?.focus();
-  // });
+    inputElm.focus();
+  });
 }
 
 /**

--- a/client/src/components/EditorImportButton.vue
+++ b/client/src/components/EditorImportButton.vue
@@ -8,8 +8,8 @@ import JsonParseError from '../utils/errors/parse.error';
 import ImportError from '../utils/errors/import.error';
 import MalformedAnnotationsError from '../utils/errors/malformedAnnotations.error';
 import IAnnotation from '../models/IAnnotation';
-import IText from '../models/IText';
 import {
+  AdditionalText,
   Annotation,
   AnnotationData,
   AnnotationProperty,
@@ -389,9 +389,7 @@ function transformStandoffToAtag(): void {
       );
 
       const newAnnotationNormdata = Object.fromEntries(normdataCategories.map(m => [m, []]));
-      const newAdditionalText: IText | null = config.hasAdditionalText
-        ? { text: '', uuid: crypto.randomUUID() }
-        : null;
+      const newAdditionalTexts: AdditionalText[] = [];
 
       let index: number = a.start;
 
@@ -411,7 +409,7 @@ function transformStandoffToAtag(): void {
       newAnnotations.push({
         properties: newAnnotationProperties,
         normdata: newAnnotationNormdata,
-        additionalText: newAdditionalText,
+        additionalTexts: newAdditionalTexts,
       });
     });
 

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -1,18 +1,28 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ComputedRef, ref } from 'vue';
 import { useCollectionStore } from '../store/collection';
 import { useGuidelinesStore } from '../store/guidelines';
 import { capitalize } from '../utils/helper/helper';
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
 import Panel from 'primevue/panel';
+import { CollectionProperty } from '../models/types';
 
 defineExpose({
   validate,
 });
 
-const { collection } = useCollectionStore();
+const { collection, collectionNodeLabel } = useCollectionStore();
 const { guidelines } = useGuidelinesStore();
+
+// TODO: Still a workaround, should be mady dynamic.
+const fields: ComputedRef<CollectionProperty[]> = computed(() => {
+  if (collectionNodeLabel.value === 'Letter') {
+    return guidelines.value.collections['text'].properties;
+  } else {
+    return guidelines.value.collections['comment'].properties;
+  }
+});
 
 const formRef = ref<HTMLFormElement | null>(null);
 
@@ -47,11 +57,7 @@ function validate(): boolean {
     </div>
 
     <form ref="formRef" @submit.prevent="validate">
-      <div
-        class="input-container"
-        v-for="field in guidelines.collections['text'].properties"
-        v-show="field.visible"
-      >
+      <div class="input-container" v-for="field in fields" v-show="field.visible">
         <div class="flex align-items-center gap-3 mb-3" v-show="field.visible">
           <label :for="field.name" class="w-10rem font-semibold"
             >{{ capitalize(field.name) }}

--- a/client/src/models/IGuidelines.ts
+++ b/client/src/models/IGuidelines.ts
@@ -13,7 +13,7 @@ export interface IGuidelines {
     };
   };
   annotations: {
-    additionalTexts: { name: string; nodeLabel: string }[];
+    additionalTexts: string[];
     types: AnnotationType[];
     properties: AnnotationProperty[];
     resources: AnnotationConfigResource[];

--- a/client/src/models/IGuidelines.ts
+++ b/client/src/models/IGuidelines.ts
@@ -13,6 +13,7 @@ export interface IGuidelines {
     };
   };
   annotations: {
+    additionalTexts: { name: string; nodeLabel: string }[];
     types: AnnotationType[];
     properties: AnnotationProperty[];
     resources: AnnotationConfigResource[];

--- a/client/src/models/IText.ts
+++ b/client/src/models/IText.ts
@@ -1,12 +1,4 @@
-import ICharacter from './ICharacter.js';
-import ICollection from './ICollection.js';
-
 export default interface IText {
-  characters?: ICharacter[];
-  guid: string;
-  metadata?: ICollection;
-  name: string;
-  normalizedText: string;
   text: string;
-  type: string;
+  uuid: string;
 }

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -4,6 +4,14 @@ import ICollection from './ICollection';
 import IEntity from './IEntity';
 import IText from './IText';
 
+export type AdditionalText = {
+  nodeLabel: string;
+  data: {
+    collection: ICollection;
+    text: IText;
+  };
+};
+
 export type Annotation = {
   characterUuids: string[];
   data: AnnotationData;
@@ -15,13 +23,7 @@ export type Annotation = {
 };
 
 export interface AnnotationData {
-  additionalTexts: {
-    nodeLabel: string;
-    data: {
-      collection: ICollection;
-      text: IText;
-    };
-  }[];
+  additionalTexts: AdditionalText[];
   normdata: {
     [index: string]: IEntity[];
   };

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -1,6 +1,7 @@
 import IAnnotation from './IAnnotation';
 import ICharacter from './ICharacter';
 import IEntity from './IEntity';
+import IText from './IText';
 
 export type Annotation = {
   characterUuids: string[];
@@ -13,10 +14,11 @@ export type Annotation = {
 };
 
 export interface AnnotationData {
-  properties: IAnnotation;
+  additionalText: IText | null;
   normdata: {
     [index: string]: IEntity[];
   };
+  properties: IAnnotation;
 }
 
 export type AnnotationType = {
@@ -24,6 +26,7 @@ export type AnnotationType = {
   defaultSelected: boolean;
   isSeparator?: boolean;
   isZeroPoint?: boolean;
+  hasAdditionalText: boolean;
   hasNormdata?: boolean;
   properties?: AnnotationProperty[];
   shortcut: string[];

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -78,6 +78,11 @@ export type CharacterPostData = {
   uuidStart: string;
 };
 
+export type Collection = {
+  data: ICollection;
+  nodeLabel: string;
+};
+
 export type CollectionProperty = {
   name: string /* folioEnd, label, websiteUrl */;
   type: string /* raw string, dropdown, multiple options */;

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -14,7 +14,10 @@ export type Annotation = {
 };
 
 export interface AnnotationData {
-  additionalText: IText | null;
+  additionalTexts: {
+    // TODO: Technically, this is not an IText. Fix when changing route structure
+    [index: string]: IText | null;
+  };
   normdata: {
     [index: string]: IEntity[];
   };
@@ -22,11 +25,11 @@ export interface AnnotationData {
 }
 
 export type AnnotationType = {
+  additionalTexts: { name: string; nodeLabel: string }[];
   category: string;
   defaultSelected: boolean;
   isSeparator?: boolean;
   isZeroPoint?: boolean;
-  hasAdditionalText: boolean;
   hasNormdata?: boolean;
   properties?: AnnotationProperty[];
   shortcut: string[];

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -1,5 +1,6 @@
 import IAnnotation from './IAnnotation';
 import ICharacter from './ICharacter';
+import ICollection from './ICollection';
 import IEntity from './IEntity';
 import IText from './IText';
 
@@ -15,9 +16,12 @@ export type Annotation = {
 
 export interface AnnotationData {
   additionalTexts: {
-    // TODO: Technically, this is not an IText. Fix when changing route structure
-    [index: string]: IText | null;
-  };
+    nodeLabel: string;
+    data: {
+      collection: ICollection;
+      text: IText;
+    };
+  }[];
   normdata: {
     [index: string]: IEntity[];
   };
@@ -25,11 +29,11 @@ export interface AnnotationData {
 }
 
 export type AnnotationType = {
-  additionalTexts: { name: string; nodeLabel: string }[];
   category: string;
   defaultSelected: boolean;
   isSeparator?: boolean;
   isZeroPoint?: boolean;
+  hasAdditionalTexts?: boolean;
   hasNormdata?: boolean;
   properties?: AnnotationProperty[];
   shortcut: string[];

--- a/client/src/store/collection.ts
+++ b/client/src/store/collection.ts
@@ -1,17 +1,21 @@
 import { ref } from 'vue';
 import ICollection from '../models/ICollection';
+import { Collection } from '../models/types';
 
 const collection = ref<ICollection>();
 const initialCollection = ref<ICollection>();
+const collectionNodeLabel = ref<string>();
 
-function initializeCollection(collectionData: ICollection): void {
-  collection.value = collectionData;
-  initialCollection.value = { ...collectionData };
+function initializeCollection(newCollection: Collection): void {
+  collection.value = newCollection.data;
+  collectionNodeLabel.value = newCollection.nodeLabel;
+  initialCollection.value = { ...newCollection.data };
 }
 export function useCollectionStore() {
   return {
     collection,
     initialCollection,
+    collectionNodeLabel,
     initializeCollection,
   };
 }

--- a/client/src/store/editor.ts
+++ b/client/src/store/editor.ts
@@ -114,21 +114,20 @@ export function useEditorStore() {
           .map(m => m.uuid),
       );
 
-      // Check if additional texts have changed (new one added, old one removed/replaced)
-      for (const [fieldName, text] of Object.entries(a.data.additionalTexts)) {
-        const textReferenceHasChanged: boolean =
-          text?.uuid !== a.initialData.additionalTexts[fieldName]?.uuid;
+      const initialAdditionalTextUuids: Set<string> = new Set(
+        a.initialData.additionalTexts.map(at => at.data.collection.uuid),
+      );
 
-        if (textReferenceHasChanged) {
-          return true;
-        }
-      }
+      const additionalTextUuids: Set<string> = new Set(
+        a.data.additionalTexts.map(at => at.data.collection.uuid),
+      );
 
       if (
         a.status === 'deleted' ||
         a.status === 'created' ||
         !areObjectsEqual(a.data.properties, a.initialData.properties) ||
-        !areSetsEqual(normdataUuids, initialNormdataUuids)
+        !areSetsEqual(normdataUuids, initialNormdataUuids) ||
+        !areSetsEqual(initialAdditionalTextUuids, additionalTextUuids)
       ) {
         console.log(`Annotation at index ${i} has a changed status or data.`);
         return true;

--- a/client/src/store/editor.ts
+++ b/client/src/store/editor.ts
@@ -114,6 +114,16 @@ export function useEditorStore() {
           .map(m => m.uuid),
       );
 
+      // Check if additional texts have changed (new one added, old one removed/replaced)
+      for (const [fieldName, text] of Object.entries(a.data.additionalTexts)) {
+        const textReferenceHasChanged: boolean =
+          text?.uuid !== a.initialData.additionalTexts[fieldName]?.uuid;
+
+        if (textReferenceHasChanged) {
+          return true;
+        }
+      }
+
       if (
         a.status === 'deleted' ||
         a.status === 'created' ||

--- a/client/src/views/Editor.vue
+++ b/client/src/views/Editor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ComputedRef, computed, onMounted, onUnmounted, ref } from 'vue';
+import { ComputedRef, computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { RouteLocationNormalizedLoaded, useRoute, onBeforeRouteLeave } from 'vue-router';
 import { useCharactersStore } from '../store/characters';
 import { useCollectionStore } from '../store/collection';
@@ -19,8 +19,13 @@ import EditorResizer from '../components/EditorResizer.vue';
 import EditorMetadata from '../components/EditorMetadata.vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
 import { buildFetchUrl, cloneDeep } from '../utils/helper/helper';
-import ICollection from '../models/ICollection';
-import { Annotation, AnnotationData, Character, CharacterPostData } from '../models/types';
+import {
+  Annotation,
+  AnnotationData,
+  Character,
+  CharacterPostData,
+  Collection,
+} from '../models/types';
 import { IGuidelines } from '../models/IGuidelines';
 import { useAnnotationStore } from '../store/annotations';
 import { useEditorStore } from '../store/editor';
@@ -143,7 +148,7 @@ async function getCollectionByUuid(): Promise<void> {
       throw new Error('Network response was not ok');
     }
 
-    const fetchedCollection: ICollection = await response.json();
+    const fetchedCollection: Collection = await response.json();
 
     isValidCollection.value = true;
     initializeCollection(fetchedCollection);

--- a/server/src/config/guidelines.json
+++ b/server/src/config/guidelines.json
@@ -32,6 +32,18 @@
           "visible": true
         }
       ]
+    },
+    "comment": {
+      "additionalLabel": "Comment",
+      "properties": [
+        {
+          "name": "label",
+          "type": "text",
+          "required": true,
+          "editable": false,
+          "visible": false
+        }
+      ]
     }
   },
   "annotations": {
@@ -205,16 +217,7 @@
         "category": "project",
         "defaultSelected": true,
         "isZeroPoint": false,
-        "additionalTexts": [
-          {
-            "name": "atagComment",
-            "nodeLabel": "Comment"
-          },
-          {
-            "name": "anotherComment",
-            "nodeLabel": "Test"
-          }
-        ]
+        "hasAdditionalTexts": true
       },
       {
         "type": "entity",
@@ -292,6 +295,7 @@
         "category": "roles",
         "nodeLabel": "Role"
       }
-    ]
+    ],
+    "additionalTexts": ["Comment", "Test"]
   }
 }

--- a/server/src/config/guidelines.json
+++ b/server/src/config/guidelines.json
@@ -205,7 +205,8 @@
         "type": "commentInternal",
         "category": "project",
         "defaultSelected": true,
-        "isZeroPoint": false
+        "isZeroPoint": false,
+        "hasAdditionalText": true
       },
       {
         "type": "entity",

--- a/server/src/config/guidelines.json
+++ b/server/src/config/guidelines.json
@@ -296,6 +296,6 @@
         "nodeLabel": "Role"
       }
     ],
-    "additionalTexts": ["Comment", "Test"]
+    "additionalTexts": ["Comment"]
   }
 }

--- a/server/src/config/guidelines.json
+++ b/server/src/config/guidelines.json
@@ -34,7 +34,6 @@
       ]
     }
   },
-
   "annotations": {
     "types": [
       {
@@ -206,7 +205,16 @@
         "category": "project",
         "defaultSelected": true,
         "isZeroPoint": false,
-        "hasAdditionalText": true
+        "additionalTexts": [
+          {
+            "name": "atagComment",
+            "nodeLabel": "Comment"
+          },
+          {
+            "name": "anotherComment",
+            "nodeLabel": "Test"
+          }
+        ]
       },
       {
         "type": "entity",

--- a/server/src/models/ICharacter.ts
+++ b/server/src/models/ICharacter.ts
@@ -1,7 +1,5 @@
 export default interface ICharacter {
-	textGuid: string;
-	letterLabel: string;
-	text: string;
-	uuid: string;
-	textUrl: string;
+  letterLabel: string;
+  text: string;
+  uuid: string;
 }

--- a/server/src/models/IGuidelines.ts
+++ b/server/src/models/IGuidelines.ts
@@ -13,7 +13,7 @@ export interface IGuidelines {
     };
   };
   annotations: {
-    additionalTexts: { name: string; nodeLabel: string }[];
+    additionalTexts: string[];
     types: AnnotationType[];
     properties: AnnotationProperty[];
     resources: AnnotationConfigResource[];

--- a/server/src/models/IGuidelines.ts
+++ b/server/src/models/IGuidelines.ts
@@ -13,6 +13,7 @@ export interface IGuidelines {
     };
   };
   annotations: {
+    additionalTexts: { name: string; nodeLabel: string }[];
     types: AnnotationType[];
     properties: AnnotationProperty[];
     resources: AnnotationConfigResource[];

--- a/server/src/models/IText.ts
+++ b/server/src/models/IText.ts
@@ -1,12 +1,4 @@
-import ICharacter from './ICharacter.js';
-import ICollection from './ICollection.js';
-
 export default interface IText {
-  characters?: ICharacter[];
-  guid: string;
-  metadata?: ICollection;
-  name: string;
-  normalizedText: string;
   text: string;
-  type: string;
+  uuid: string;
 }

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -1,5 +1,6 @@
 import IAnnotation from './IAnnotation.js';
 import ICharacter from './ICharacter.js';
+import ICollection from './ICollection.js';
 import IEntity from './IEntity.js';
 import IText from './IText.js';
 
@@ -15,9 +16,12 @@ export type Annotation = {
 
 export interface AnnotationData {
   additionalTexts: {
-    // TODO: Technically, this is not an IText. Fix when changing route structure
-    [index: string]: IText | null;
-  };
+    nodeLabel: string;
+    data: {
+      collection: ICollection;
+      text: IText;
+    };
+  }[];
   normdata: {
     [index: string]: IEntity[];
   };
@@ -25,11 +29,11 @@ export interface AnnotationData {
 }
 
 export type AnnotationType = {
-  additionalTexts: { name: string; nodeLabel: string }[];
   category: string;
   defaultSelected: boolean;
   isSeparator?: boolean;
   isZeroPoint?: boolean;
+  hasAdditionalTexts?: boolean;
   hasNormdata?: boolean;
   properties?: AnnotationProperty[];
   shortcut: string[];

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -77,6 +77,11 @@ export type CharacterPostData = {
   characters: ICharacter[];
 };
 
+export type Collection = {
+  data: ICollection;
+  nodeLabel: string;
+};
+
 export type CollectionProperty = {
   name: string /* folioEnd, label, websiteUrl */;
   type: string /* raw string, dropdown, multiple options */;

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -1,6 +1,7 @@
 import IAnnotation from './IAnnotation.js';
 import ICharacter from './ICharacter.js';
 import IEntity from './IEntity.js';
+import IText from './IText.js';
 
 export type Annotation = {
   characterUuids: string[];
@@ -13,10 +14,11 @@ export type Annotation = {
 };
 
 export interface AnnotationData {
-  properties: IAnnotation;
+  additionalText: IText | null;
   normdata: {
     [index: string]: IEntity[];
   };
+  properties: IAnnotation;
 }
 
 export type AnnotationType = {
@@ -24,6 +26,7 @@ export type AnnotationType = {
   defaultSelected: boolean;
   isSeparator?: boolean;
   isZeroPoint?: boolean;
+  hasAdditionalText: boolean;
   hasNormdata?: boolean;
   properties?: AnnotationProperty[];
   shortcut: string[];

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -14,7 +14,10 @@ export type Annotation = {
 };
 
 export interface AnnotationData {
-  additionalText: IText | null;
+  additionalTexts: {
+    // TODO: Technically, this is not an IText. Fix when changing route structure
+    [index: string]: IText | null;
+  };
   normdata: {
     [index: string]: IEntity[];
   };
@@ -22,11 +25,11 @@ export interface AnnotationData {
 }
 
 export type AnnotationType = {
+  additionalTexts: { name: string; nodeLabel: string }[];
   category: string;
   defaultSelected: boolean;
   isSeparator?: boolean;
   isZeroPoint?: boolean;
-  hasAdditionalText: boolean;
   hasNormdata?: boolean;
   properties?: AnnotationProperty[];
   shortcut: string[];

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -4,6 +4,14 @@ import ICollection from './ICollection.js';
 import IEntity from './IEntity.js';
 import IText from './IText.js';
 
+export type AdditionalText = {
+  nodeLabel: string;
+  data: {
+    collection: ICollection;
+    text: IText;
+  };
+};
+
 export type Annotation = {
   characterUuids: string[];
   data: AnnotationData;
@@ -15,13 +23,7 @@ export type Annotation = {
 };
 
 export interface AnnotationData {
-  additionalTexts: {
-    nodeLabel: string;
-    data: {
-      collection: ICollection;
-      text: IText;
-    };
-  }[];
+  additionalTexts: AdditionalText[];
   normdata: {
     [index: string]: IEntity[];
   };

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -5,6 +5,7 @@ import CollectionService from '../services/collection.service.js';
 import GuidelinesService from '../services/guidelines.service.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
+import { Collection } from '../models/types.js';
 
 const router: Router = express.Router({ mergeParams: true });
 
@@ -46,7 +47,8 @@ router.get('/:uuid', async (req: Request, res: Response, next: NextFunction) => 
   const uuid: string = req.params.uuid;
 
   try {
-    const collection: ICollection = await collectionService.getCollectionById(uuid);
+    // TODO: Part of the collection metadata workaround, fix later
+    const collection: Collection = await collectionService.getExtendedCollectionById(uuid);
 
     res.status(200).json(collection);
   } catch (error: unknown) {

--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -196,9 +196,12 @@ export default class AnnotationService {
         WHERE delAnnotation.status = 'deleted'
         MATCH (a:Annotation {uuid: delAnnotation.data.properties.uuid})
         WITH a
-        // This deletes the whole network attached to the annotation node
-        OPTIONAL MATCH p = (a)-[:REFERS_TO | HAS_TEXT | HAS_ANNOTATION | NEXT_CHARACTER*]->(x:Collection | Text | Character | Annotation)
-        DETACH DELETE a, p
+        // Match connected Text, Annotation and Annotation nodes
+        OPTIONAL MATCH (a)-[:REFERS_TO | HAS_TEXT | HAS_ANNOTATION*]->(x:Collection | Text | Annotation)
+        WITH a, x
+        // Find optional character chain for text nodes
+        OPTIONAL MATCH (x)-[:NEXT_CHARACTER*]->(ch:Character)
+        DETACH DELETE a, x, ch
     }
 
     WITH allAnnotations
@@ -242,8 +245,12 @@ export default class AnnotationService {
         WITH ann, a
         UNWIND ann.data.additionalTexts.deleted as textToDelete
 
-        OPTIONAL MATCH p = (a)-[:REFERS_TO | HAS_TEXT | HAS_ANNOTATION | NEXT_CHARACTER*]->(x:Collection | Text | Character | Annotation)
-        DETACH DELETE x
+        // Match connected Text, Annotation and Annotation nodes
+        OPTIONAL MATCH (a)-[:REFERS_TO | HAS_TEXT | HAS_ANNOTATION*]->(x:Collection | Text | Annotation)
+        WITH x
+        // Find optional character chain for text nodes
+        OPTIONAL MATCH (x)-[:NEXT_CHARACTER*]->(ch:Character)
+        DETACH DELETE x, ch
     }
 
     // Create additional text nodes

--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -47,11 +47,23 @@ export default class AnnotationService {
     // Create key-value pair with category and matched nodes
     WITH a, collect({category: key, nodes: nodes}) AS normdata
 
+    // Fetch additional text optionally
+    CALL {
+        WITH a
+        
+        OPTIONAL MATCH (a)-[:REFERS_TO]->(t:Text)
+
+        RETURN t {.*} as additionalText
+    }
+
+    WITH a, normdata, additionalText
+
     RETURN collect({
         properties: a {.*},
-        normdata: apoc.map.fromPairs([m IN normdata | [m.category, m.nodes]])
+        normdata: apoc.map.fromPairs([m IN normdata | [m.category, m.nodes]]),
+        additionalText: additionalText
     }) AS annotations
-`;
+    `;
 
     const result: QueryResult = await Neo4jDriver.runQuery(query, { collectionUuid, resources });
 


### PR DESCRIPTION
Allow annotation properties to be edited as ATAG text, not only plain text. These texts are not stored in the Annotation node, but as new `Collection`/`Text`node combination with an optional `Character` chain.

Key changes:
- The `data` property of the `annotation` object get a separate key `additionalTexts` that holds an array of the new `Collection`/`Text` node combinations. `Annotation` and `Collection` nodes are connected via `REFERS_TO` relationships. The `Collection` nodes have an additional node label that specifies its nature and can be configured in the Guidelines (currently, only `Comment` is allowed).
- Additional texts can be added and removed from inside the annotation form. 
- To edit new created additional texts, the current state of the editor needs to be stored in the database. The new `Collection`/`Text`/`Character` nodes will be created and can be edited via a separate Editor instance in a new tab with. The texts are accessible via utgoing links from the annotation form.
- These additional texts have their own set of metadata which will be stored in the `Collection` node and displayed in the Metadata tab. These fields are configured in the Guidelines.

The current implementation is WIP and contains temporary hacks which are marked in Todo's. For example, the guideline structure needs to be improved since some things are hardcoded, and no breadcrumbs or similar indicators of the text's position in the graph exist yet.