### PR TITLE
Change relationship name and direction between Text and Collection nodes

### DIFF
--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -36,7 +36,7 @@ export default class AnnotationService {
 
     const query: string = `
     // Match all annotations for given selection
-    MATCH (c:Collection {uuid: $collectionUuid})-[:HAS_TEXT]->(t:Text)-[:HAS_ANNOTATION]->(a:Annotation)
+    MATCH (c:Collection {uuid: $collectionUuid})<-[:PART_OF]-(t:Text)-[:HAS_ANNOTATION]->(a:Annotation)
 
     // Fetch additional nodes by label defined in the guidelines
     WITH a, $guidelines.annotations.resources AS resources
@@ -64,7 +64,7 @@ export default class AnnotationService {
     CALL {
         WITH a, atLabel
 
-        MATCH (a)-[r:REFERS_TO]->(x:Collection)-[:HAS_TEXT]->(t2:Text)
+        MATCH (a)-[r:REFERS_TO]->(x:Collection)<-[:PART_OF]-(t2:Text)
         WHERE atLabel IN labels(x)
         RETURN collect({
             nodeLabel: atLabel,
@@ -197,7 +197,7 @@ export default class AnnotationService {
         MATCH (a:Annotation {uuid: delAnnotation.data.properties.uuid})
         WITH a
         // Match connected Text, Annotation and Annotation nodes
-        OPTIONAL MATCH (a)-[:REFERS_TO | HAS_TEXT | HAS_ANNOTATION*]->(x:Collection | Text | Annotation)
+        OPTIONAL MATCH (a)-[:REFERS_TO | PART_OF | HAS_ANNOTATION*]-(x:Collection | Text | Annotation)
         WITH a, x
         // Find optional character chain for text nodes
         OPTIONAL MATCH (x)-[:NEXT_CHARACTER*]->(ch:Character)
@@ -206,7 +206,7 @@ export default class AnnotationService {
 
     WITH allAnnotations
 
-    MATCH (c:Collection {uuid: $collectionUuid})-[:HAS_TEXT]->(t:Text)
+    MATCH (c:Collection {uuid: $collectionUuid})<-[:PART_OF]-(t:Text)
 
     // 2. Handle other annotations (merge)
     UNWIND allAnnotations AS ann
@@ -247,7 +247,7 @@ export default class AnnotationService {
 
         // Match connected Collection, Text and Annotation nodes
         OPTIONAL MATCH (a)-[:REFERS_TO]->(c:Collection {uuid: textToDelete.data.collection.uuid})
-        -[:REFERS_TO | HAS_TEXT | HAS_ANNOTATION*]->(x:Collection | Text | Annotation)
+        -[:REFERS_TO | PART_OF | HAS_ANNOTATION*]-(x:Collection | Text | Annotation)
         WITH c, x
         // Find optional character chain for Text nodes
         OPTIONAL MATCH (x)-[:NEXT_CHARACTER*]->(ch:Character)
@@ -259,7 +259,7 @@ export default class AnnotationService {
         WITH ann, a
         UNWIND ann.data.additionalTexts.created as textToCreate
         
-        CREATE (a)-[:REFERS_TO]->(c:Collection)-[:HAS_TEXT]->(t:Text)
+        CREATE (a)-[:REFERS_TO]->(c:Collection)<-[:PART_OF]-(t:Text)
 
         WITH textToCreate, a, c, t
 
@@ -304,7 +304,7 @@ export default class AnnotationService {
 
     // Set startIndex and andIndex properties of Annotation nodes
     
-    MATCH (c:Collection {uuid: $collectionUuid})-[:HAS_TEXT]->(t:Text)-[:NEXT_CHARACTER*]->(ch:Character)
+    MATCH (c:Collection {uuid: $collectionUuid})<-[:PART_OF]-(t:Text)-[:NEXT_CHARACTER*]->(ch:Character)
     WITH collect(ch) as characters, annotations
 
     UNWIND range(0, size(characters) - 1) AS idx

--- a/server/src/services/character.service.ts
+++ b/server/src/services/character.service.ts
@@ -12,7 +12,7 @@ export default class CharacterService {
    */
   public async getCharacters(collectionUuid: string): Promise<Character[]> {
     const query: string = `
-    MATCH (c:Collection {uuid: $collectionUuid})-[:HAS_TEXT]->(t:Text)-[:NEXT_CHARACTER*]->(char:Character)
+    MATCH (c:Collection {uuid: $collectionUuid})<-[:PART_OF]-(t:Text)-[:NEXT_CHARACTER*]->(char:Character)
     WITH char, [(char)-[:CHARACTER_HAS_ANNOTATION]->(a:Annotation) | 
       {
         uuid: a.uuid,
@@ -50,7 +50,7 @@ export default class CharacterService {
     text: string,
   ): Promise<ICharacter[]> {
     const query: string = `
-    MATCH (c:Collection {uuid: $collectionUuid})-[:HAS_TEXT]->(t:Text)
+    MATCH (c:Collection {uuid: $collectionUuid})<-[:PART_OF]-(t:Text)
     SET t.text = $text
     WITH t
     CALL atag.chains.update(t.uuid, $uuidStart, $uuidEnd, $characters, {

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -98,7 +98,7 @@ export default class CollectionService {
     data = { ...data, uuid: crypto.randomUUID() };
 
     const query: string = `
-    CREATE (c:Collection:${additionalLabel} $data)-[:HAS_TEXT]->(t:Text {uuid: $textUuid})
+    CREATE (c:Collection:${additionalLabel} $data)<-[:PART_OF]-(t:Text {uuid: $textUuid})
     RETURN c {.*} AS collection
     `;
 
@@ -140,7 +140,7 @@ export default class CollectionService {
    */
   public async deleteCollection(uuid: string): Promise<ICollection> {
     const query: string = `
-    MATCH (c:Collection {uuid: $uuid})-[:HAS_TEXT]->(t:Text)
+    MATCH (c:Collection {uuid: $uuid})<-[:PART_OF]-(t:Text)
     OPTIONAL MATCH (t)-[:NEXT_CHARACTER*]->(chars:Character)
     WITH c, t, chars, c {.*} as collection
     DETACH DELETE c, t, chars


### PR DESCRIPTION
The name and the direction between `Text` and `Collection` nodes were updated to match the new data model. From `(Collection)-[HAS_TEXT)->(Text)` to `(Collection)<-[PART_OF)-(Text)`. Mainly an adjustment of the cypher queries. Done in a separate branch to prevent unwanted bugs. 