### PR TITLE
Allow multiple Texts for Collections

### DIFF
--- a/client/src/components/CollectionError.vue
+++ b/client/src/components/CollectionError.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import Button from 'primevue/button';
+
+defineProps<{ uuid: string }>();
+</script>
+
+<template>
+  <div class="error-container flex flex-column justify-content-center align-items-center gap-4">
+    <div class="text">A Collection with UUID {{ uuid }} does not exist :/</div>
+    <RouterLink to="/">
+      <Button aria-label="Home">Go to overview</Button>
+    </RouterLink>
+  </div>
+</template>
+
+<style scoped>
+.error-container {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+</style>

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -614,7 +614,7 @@ function handleDeleteAdditionalText(collectionUuid: string): void {
           </div>
           <div class="flex align-items-center gap-2 overflow">
             <a
-              :href="`/texts/${additionalText.data.collection.uuid}`"
+              :href="`/texts/${additionalText.data.text.uuid}`"
               title="Open text in new editor tab"
               class="flex align-items-center gap-1"
               target="_blank"

--- a/client/src/components/EditorAnnotations.vue
+++ b/client/src/components/EditorAnnotations.vue
@@ -159,7 +159,7 @@ function toggleViewMode(direction: 'current' | 'all'): void {
 
 <template>
   <Panel
-    class="annotations-container mb-3 overflow-y-auto"
+    class="annotations-container mb-3"
     toggleable
     :toggle-button-props="{
       severity: 'secondary',

--- a/client/src/components/EditorHeader.vue
+++ b/client/src/components/EditorHeader.vue
@@ -32,15 +32,16 @@ const breadcrumbItems = ref([{ role: 'Text', labels: text.value.nodeLabels }]);
       <Breadcrumb :home="breadcrumbRoot" :model="breadcrumbItems">
         <template #item="{ item }">
           <div v-if="item.role === 'Collection'">
-            <span>
-              {{ item.label }}
-            </span>
+            <Tag :value="item.label" severity="contrast" :title="`Collection: ${item.label}`" />
           </div>
           <div v-else>
-            <template v-if="item.labels.length > 0" v-for="label in item.labels">
-              <Tag :value="label" severity="secondary" class="mr-1" />
-            </template>
-            <span v-else><i>No label yet</i></span>
+            <Tag
+              v-if="item.labels.length > 0"
+              :value="item.labels.join(' | ')"
+              severity="secondary"
+              :title="`Text labels: ${item.labels.join(', ')}`"
+            />
+            <Tag v-else="" :value="'\u00A0'" severity="secondary" title="No label yet" />
           </div>
         </template>
       </Breadcrumb>

--- a/client/src/components/EditorHeader.vue
+++ b/client/src/components/EditorHeader.vue
@@ -7,8 +7,8 @@ import Button from 'primevue/button';
 
 const { text, correspondingCollection } = useTextStore();
 
-const home = ref({ label: '(C) ' + correspondingCollection.value.data.label });
-const items = ref([{ label: text.value.nodeLabel }]);
+const home = ref({ labels: '(C) ' + correspondingCollection.value.data.label });
+const items = ref([{ labels: text.value.nodeLabels }]);
 </script>
 
 <template>
@@ -30,7 +30,7 @@ const items = ref([{ label: text.value.nodeLabel }]);
     <div class="flex justify-content-center">
       <Breadcrumb :home="home" :model="items">
         <template #item="{ item }">
-          <span v-if="item.label">{{ item.label }}</span>
+          <span v-if="item.labels.length > 0">{{ item.labels }}</span>
           <span v-else><i>No label yet</i></span>
         </template>
       </Breadcrumb>

--- a/client/src/components/EditorHeader.vue
+++ b/client/src/components/EditorHeader.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import EditorImportButton from './EditorImportButton.vue';
 import { useTextStore } from '../store/text';
+import Breadcrumb from 'primevue/breadcrumb';
 import Button from 'primevue/button';
 
-const { text } = useTextStore();
+const { text, correspondingCollection } = useTextStore();
+
+const home = ref({ label: '(C) ' + correspondingCollection.value.data.label });
+const items = ref([{ label: text.value.nodeLabel }]);
 </script>
 
 <template>
@@ -21,8 +26,14 @@ const { text } = useTextStore();
         <EditorImportButton />
       </div>
     </div>
-    <div class="label flex justify-content-center text-center">
-      {{ text.nodeLabel ?? 'no Text label provided yet :/' }}
+
+    <div class="flex justify-content-center">
+      <Breadcrumb :home="home" :model="items">
+        <template #item="{ item }">
+          <span v-if="item.label">{{ item.label }}</span>
+          <span v-else><i>No label yet</i></span>
+        </template>
+      </Breadcrumb>
     </div>
   </div>
 </template>

--- a/client/src/components/EditorHeader.vue
+++ b/client/src/components/EditorHeader.vue
@@ -1,34 +1,9 @@
 <script setup lang="ts">
-import { WritableComputedRef, computed, ref } from 'vue';
-import { useCollectionStore } from '../store/collection';
 import EditorImportButton from './EditorImportButton.vue';
+import { useTextStore } from '../store/text';
 import Button from 'primevue/button';
-import InputText from 'primevue/inputtext';
 
-defineExpose({
-  validate,
-});
-
-const { collection } = useCollectionStore();
-
-// This allows using v-model for title input changes.
-// TODO: Replace with more generic async handling later
-const displayedLabel: WritableComputedRef<string> = computed({
-  get() {
-    return collection.value?.label || '';
-  },
-  set(value: string) {
-    if (collection.value) {
-      collection.value.label = value;
-    }
-  },
-});
-
-const formRef = ref<HTMLFormElement | null>(null);
-
-function validate(): boolean {
-  return formRef.value.reportValidity();
-}
+const { text } = useTextStore();
 </script>
 
 <template>
@@ -47,42 +22,9 @@ function validate(): boolean {
       </div>
     </div>
     <div class="label flex justify-content-center text-center">
-      <form ref="formRef" action="" class="w-full px-3">
-        <InputText
-          id="label"
-          v-model="displayedLabel"
-          required
-          spellcheck="false"
-          :invalid="displayedLabel.length === 0"
-          placeholder="No label provided"
-          class="input-label text-center w-full text-xl font-bold"
-        />
-      </form>
+      {{ text.nodeLabel ?? 'no Text label provided yet :/' }}
     </div>
   </div>
 </template>
 
-<style scoped>
-.input-label {
-  border: none;
-  outline: 0;
-  box-shadow: none;
-
-  &[aria-invalid='true'] {
-    outline: 1px solid var(--color-input-invalid);
-  }
-
-  &:hover:not(:focus-visible) {
-    background-color: rgba(var(--color-blue-base), 0.05);
-  }
-
-  &::placeholder {
-    color: rgb(255, 173, 173);
-    font-weight: normal;
-  }
-
-  &:focus-visible {
-    box-shadow: var(--box-shadow-focus);
-  }
-}
-</style>
+<style scoped></style>

--- a/client/src/components/EditorHeader.vue
+++ b/client/src/components/EditorHeader.vue
@@ -4,11 +4,12 @@ import EditorImportButton from './EditorImportButton.vue';
 import { useTextStore } from '../store/text';
 import Breadcrumb from 'primevue/breadcrumb';
 import Button from 'primevue/button';
+import Tag from 'primevue/tag';
 
 const { text, correspondingCollection } = useTextStore();
 
-const home = ref({ labels: '(C) ' + correspondingCollection.value.data.label });
-const items = ref([{ labels: text.value.nodeLabels }]);
+const breadcrumbRoot = ref({ role: 'Collection', label: correspondingCollection.value.data.label });
+const breadcrumbItems = ref([{ role: 'Text', labels: text.value.nodeLabels }]);
 </script>
 
 <template>
@@ -28,10 +29,19 @@ const items = ref([{ labels: text.value.nodeLabels }]);
     </div>
 
     <div class="flex justify-content-center">
-      <Breadcrumb :home="home" :model="items">
+      <Breadcrumb :home="breadcrumbRoot" :model="breadcrumbItems">
         <template #item="{ item }">
-          <span v-if="item.labels.length > 0">{{ item.labels }}</span>
-          <span v-else><i>No label yet</i></span>
+          <div v-if="item.role === 'Collection'">
+            <span>
+              {{ item.label }}
+            </span>
+          </div>
+          <div v-else>
+            <template v-if="item.labels.length > 0" v-for="label in item.labels">
+              <Tag :value="label" severity="secondary" class="mr-1" />
+            </template>
+            <span v-else><i>No label yet</i></span>
+          </div>
         </template>
       </Breadcrumb>
     </div>

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -37,6 +37,19 @@ function getCollectionTableData() {
 async function handleCopy(): Promise<void> {
   await navigator.clipboard.writeText(text.value.data.uuid);
 }
+
+function getNodeLabelTagColor(nodeLabels: string[]) {
+  switch (true) {
+    case nodeLabels.includes('Collection'):
+      return 'contrast';
+    case nodeLabels.includes('Text'):
+      return 'secondary';
+    case nodeLabels.includes('Annotation'):
+      return 'warn';
+    default:
+      return '';
+  }
+}
 </script>
 
 <template>
@@ -87,23 +100,32 @@ async function handleCopy(): Promise<void> {
       </div>
     </Fieldset>
 
-    <Fieldset legend="Ancestry path" toggleable>
+    <Fieldset legend="Ancestry path" toggleable collapsed>
       <template #toggleicon="{ collapsed }">
         <span :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></span>
       </template>
       <ul>
-        <li v-for="(node, index) in path" :style="`margin-left: ${index}rem`">
+        <li v-for="(node, index) in path" class="mb-1" :style="`margin-left: ${index}rem`">
           <span v-if="index !== 0">-></span>
 
           <RouterLink
-            v-if="node['nodeLabels'].includes('Collection')"
+            v-if="node.nodeLabels.includes('Collection')"
             :to="`/collections/${node.data.uuid}`"
+            :title="`Go to Collection ${node.data.uuid}`"
           >
-            {{ node['nodeLabels'] }}
+            <Tag
+              :value="node.nodeLabels.join(' | ')"
+              :severity="getNodeLabelTagColor(node.nodeLabels)"
+              class="mr-2"
+            />
             <i class="pi pi-external-link"></i>
           </RouterLink>
           <span v-else>
-            {{ node['nodeLabels'] }}
+            <Tag
+              :value="node.nodeLabels.join(' | ')"
+              :severity="getNodeLabelTagColor(node.nodeLabels)"
+              class="mr-2"
+            />
           </span>
         </li>
       </ul>
@@ -113,8 +135,12 @@ async function handleCopy(): Promise<void> {
       <template #toggleicon="{ collapsed }">
         <span :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></span>
       </template>
-      <RouterLink :to="`/collections/${correspondingCollection.data.uuid}`">Collection</RouterLink>
-      <i class="pi pi-external-link"></i>
+      <RouterLink
+        :to="`/collections/${correspondingCollection.data.uuid}`"
+        class="block w-full text-center"
+        >Go to Collection <i class="pi pi-external-link"></i
+      ></RouterLink>
+
       <DataTable
         :value="tableData"
         scrollable

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { RouterLink } from 'vue-router';
 import { useGuidelinesStore } from '../store/guidelines';
 import { useTextStore } from '../store/text';
 import { capitalize } from '../utils/helper/helper';
@@ -112,7 +113,7 @@ async function handleCopy(): Promise<void> {
       <template #toggleicon="{ collapsed }">
         <span :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></span>
       </template>
-      <a :href="`/collections/${correspondingCollection.data.uuid}`">Collection</a>
+      <RouterLink :to="`/collections/${correspondingCollection.data.uuid}`">Collection</RouterLink>
       <i class="pi pi-external-link"></i>
       <DataTable
         :value="tableData"

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useGuidelinesStore } from '../store/guidelines';
 import { useTextStore } from '../store/text';
 import { capitalize } from '../utils/helper/helper';
@@ -6,8 +7,10 @@ import { CollectionProperty } from '../models/types';
 import Button from 'primevue/button';
 import Column from 'primevue/column';
 import DataTable from 'primevue/datatable';
+import Fieldset from 'primevue/fieldset';
 import InputText from 'primevue/inputtext';
 import Panel from 'primevue/panel';
+import RadioButton from 'primevue/radiobutton';
 
 type CollectionTableEntry = {
   property: string;
@@ -16,6 +19,12 @@ type CollectionTableEntry = {
 
 const { text, correspondingCollection, path } = useTextStore();
 const { getCollectionFields } = useGuidelinesStore();
+
+const currentTextLabel = ref();
+const allowedTextLabels = ref([
+  { name: 'MainText', key: 'M' },
+  { name: 'Comment', key: 'C' },
+]);
 
 const tableData: CollectionTableEntry[] = getTableData();
 
@@ -73,8 +82,30 @@ async function handleCopy(): Promise<void> {
       </div>
       <small>Text UUID</small>
     </div>
-    <div>
-      Path:
+    <Fieldset legend="Text labels" toggleable>
+      <template #toggleicon="{ collapsed }">
+        <span :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></span>
+      </template>
+      <div
+        v-for="category in allowedTextLabels"
+        :key="category.key"
+        class="flex items-center gap-2"
+      >
+        <RadioButton
+          variant="filled"
+          v-model="currentTextLabel"
+          :inputId="category.key"
+          name="dynamic"
+          :value="category.name"
+        />
+        <label :for="category.key">{{ category.name }}</label>
+      </div>
+    </Fieldset>
+
+    <Fieldset legend="Ancestry path" toggleable>
+      <template #toggleicon="{ collapsed }">
+        <span :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></span>
+      </template>
       <ul>
         <li v-for="(node, index) in path" :style="`margin-left: ${index}rem`">
           <span v-if="index !== 0">-></span>
@@ -91,32 +122,35 @@ async function handleCopy(): Promise<void> {
           </span>
         </li>
       </ul>
-    </div>
+    </Fieldset>
 
-    <a :href="`/collections/${correspondingCollection.data.uuid}`">Collection</a>
-    <i class="pi pi-external-link"></i>
-    Data
-
-    <DataTable
-      :value="tableData"
-      scrollable
-      scrollHeight="flex"
-      resizableColumns
-      rowHover
-      tableStyle="table-layout: fixed;"
-      size="small"
-    >
-      <Column field="property" header="Property">
-        <template #body="{ data }">
-          <span>{{ capitalize(data['property']) }}</span>
-        </template>
-      </Column>
-      <Column field="value" header="Value">
-        <template #body="{ data }">
-          <span>{{ data['value'] }}</span>
-        </template>
-      </Column>
-    </DataTable>
+    <Fieldset legend="Collection" toggleable>
+      <template #toggleicon="{ collapsed }">
+        <span :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></span>
+      </template>
+      <a :href="`/collections/${correspondingCollection.data.uuid}`">Collection</a>
+      <i class="pi pi-external-link"></i>
+      <DataTable
+        :value="tableData"
+        scrollable
+        scrollHeight="flex"
+        resizableColumns
+        rowHover
+        tableStyle="table-layout: fixed;"
+        size="small"
+      >
+        <Column field="property" header="Property">
+          <template #body="{ data }">
+            <span>{{ capitalize(data['property']) }}</span>
+          </template>
+        </Column>
+        <Column field="value" header="Value">
+          <template #body="{ data }">
+            <span>{{ data['value'] }}</span>
+          </template>
+        </Column>
+      </DataTable>
+    </Fieldset>
   </Panel>
 </template>
 

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -96,7 +96,13 @@ function getNodeLabelTagColor(nodeLabels: string[]) {
         <div v-if="text.nodeLabels.length > 0" v-for="label in text.nodeLabels" :key="label">
           <Tag :value="label" severity="secondary" class="mr-1" />
         </div>
-        <div v-else><i>This text has no labels yet</i></div>
+        <div v-else>
+          <i
+            >This text has no labels yet. To add some, go to the
+            <RouterLink :to="`/collections/${correspondingCollection.data.uuid}`"
+              >Collection page.<i class="pi pi-external-link ml-2"></i></RouterLink
+          ></i>
+        </div>
       </div>
     </Fieldset>
 
@@ -138,7 +144,7 @@ function getNodeLabelTagColor(nodeLabels: string[]) {
       <RouterLink
         :to="`/collections/${correspondingCollection.data.uuid}`"
         class="block w-full text-center"
-        >Go to Collection <i class="pi pi-external-link"></i
+        >Go to Collection page<i class="pi pi-external-link ml-2"></i
       ></RouterLink>
 
       <DataTable

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -52,30 +52,43 @@ async function handleCopy(): Promise<void> {
     <template #toggleicon="{ collapsed }">
       <i :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></i>
     </template>
-    Text UUID:
-    <div class="flex align-items-center gap-3 mb-3">
-      <InputText
-        id="uuid"
-        :disabled="true"
-        :value="text.data.uuid"
-        class="flex-auto w-full"
-        size="small"
-        spellcheck="false"
-      />
-      <Button
-        icon="pi pi-copy"
-        severity="secondary"
-        size="small"
-        aria-label="Copy UUID"
-        title="Copy UUID"
-        @click="handleCopy"
-      />
+    <div class="mb-3">
+      <div class="flex align-items-center gap-3">
+        <InputText
+          id="uuid"
+          :disabled="true"
+          :value="text.data.uuid"
+          class="flex-auto w-full"
+          size="small"
+          spellcheck="false"
+        />
+        <Button
+          icon="pi pi-copy"
+          severity="secondary"
+          size="small"
+          aria-label="Copy UUID"
+          title="Copy UUID"
+          @click="handleCopy"
+        />
+      </div>
+      <small>Text UUID</small>
     </div>
     <div>
       Path:
       <ul>
-        <li v-for="segment in path['segments']" class="mx-2 list-disc">
-          {{ segment.start.labels }}
+        <li v-for="(node, index) in path" :style="`margin-left: ${index}rem`">
+          <span v-if="index !== 0">-></span>
+
+          <RouterLink
+            v-if="node['nodeLabels'].includes('Collection')"
+            :to="`/collections/${node.data.uuid}`"
+          >
+            {{ node['nodeLabels'] }}
+            <i class="pi pi-external-link"></i>
+          </RouterLink>
+          <span v-else>
+            {{ node['nodeLabels'] }}
+          </span>
         </li>
       </ul>
     </div>

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { ref } from 'vue';
 import { useGuidelinesStore } from '../store/guidelines';
 import { useTextStore } from '../store/text';
 import { capitalize } from '../utils/helper/helper';
@@ -10,7 +9,7 @@ import DataTable from 'primevue/datatable';
 import Fieldset from 'primevue/fieldset';
 import InputText from 'primevue/inputtext';
 import Panel from 'primevue/panel';
-import RadioButton from 'primevue/radiobutton';
+import Tag from 'primevue/tag';
 
 type CollectionTableEntry = {
   property: string;
@@ -20,20 +19,13 @@ type CollectionTableEntry = {
 const { text, correspondingCollection, path } = useTextStore();
 const { getCollectionFields } = useGuidelinesStore();
 
-const currentTextLabel = ref();
-const allowedTextLabels = ref([
-  { name: 'MainText', key: 'M' },
-  { name: 'Comment', key: 'C' },
-]);
+const tableData: CollectionTableEntry[] = getCollectionTableData();
 
-const tableData: CollectionTableEntry[] = getTableData();
-
-function getTableData() {
+function getCollectionTableData() {
   // TODO: Still a workaround, should be mady dynamic.
-  const fields: CollectionProperty[] =
-    correspondingCollection.value.nodeLabel === 'Letter'
-      ? getCollectionFields('text')
-      : getCollectionFields('comment');
+  const fields: CollectionProperty[] = correspondingCollection.value.nodeLabels.includes('Letter')
+    ? getCollectionFields('text')
+    : getCollectionFields('comment');
 
   return fields.map(field => ({
     property: field.name,
@@ -86,19 +78,11 @@ async function handleCopy(): Promise<void> {
       <template #toggleicon="{ collapsed }">
         <span :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></span>
       </template>
-      <div
-        v-for="category in allowedTextLabels"
-        :key="category.key"
-        class="flex items-center gap-2"
-      >
-        <RadioButton
-          variant="filled"
-          v-model="currentTextLabel"
-          :inputId="category.key"
-          name="dynamic"
-          :value="category.name"
-        />
-        <label :for="category.key">{{ category.name }}</label>
+      <div class="flex gap-2">
+        <div v-if="text.nodeLabels.length > 0" v-for="label in text.nodeLabels" :key="label">
+          <Tag :value="label" severity="secondary" class="mr-1" />
+        </div>
+        <div v-else><i>This text has no labels yet</i></div>
       </div>
     </Fieldset>
 

--- a/client/src/components/EditorSidebar.vue
+++ b/client/src/components/EditorSidebar.vue
@@ -17,7 +17,7 @@ const sidebarWidth = computed(() => props.width);
   <section
     :sidebar-id="position"
     :class="['sidebar', 'sidebar-' + position, isCollapsed ? 'collapsed' : '']"
-    class="p-3 flex flex-column"
+    class="p-3 flex flex-column overflow-y-auto"
     :style="{ width: sidebarWidth + 'px', background: '#e9e9e9' }"
   >
     <slot></slot>

--- a/client/src/components/EditorText.vue
+++ b/client/src/components/EditorText.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ComputedRef, onMounted, onUpdated, ref } from 'vue';
 import { useCharactersStore } from '../store/characters';
-import { useCollectionStore } from '../store/collection';
+import { useTextStore } from '../store/text';
 import EditorTextNavigation from './EditorTextNavigation.vue';
 import {
   findEndOfWord,
@@ -32,7 +32,7 @@ onUpdated(() => {
 });
 
 const { keepTextOnPagination, newRangeAnchorUuid, placeCaret } = useEditorStore();
-const { collection } = useCollectionStore();
+const { correspondingCollection } = useTextStore();
 const {
   afterEndIndex,
   beforeStartIndex,
@@ -635,7 +635,7 @@ function createNewCharacter(char: string): Character {
   return {
     data: {
       text: char,
-      letterLabel: collection.value.label,
+      letterLabel: correspondingCollection.value.data.label,
       uuid: crypto.randomUUID(),
     },
     annotations: [],

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ComputedRef, onMounted, ref } from 'vue';
+import { RouterLink } from 'vue-router';
 import { useGuidelinesStore } from '../store/guidelines';
 import LoadingSpinner from './LoadingSpinner.vue';
 import { buildFetchUrl, capitalize } from '../utils/helper/helper';
@@ -85,12 +86,12 @@ async function getGuidelines(): Promise<void> {
         <template #body="{ data }">
           <!-- TODO: This should come from the configuration... -->
           <!-- TODO: Bit hacky. Beautify? -->
-          <a
+          <RouterLink
             v-if="col === 'label'"
             class="cell-link"
-            :href="'/collections/' + data.uuid"
+            :to="`/collections/${data.uuid}`"
             v-tooltip.hover.top="{ value: data[col], showDelay: 0 }"
-            >{{ data[col] }}</a
+            >{{ data[col] }}</RouterLink
           >
           <span
             v-else-if="col !== 'texts'"

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -61,7 +61,6 @@ async function getGuidelines(): Promise<void> {
     <DataTable
       v-else
       scrollable
-      :rowClass="() => 'bitch'"
       scrollHeight="flex"
       :value="tableData"
       paginator
@@ -99,7 +98,7 @@ async function getGuidelines(): Promise<void> {
             v-tooltip.hover.top="{ value: data[col], showDelay: 0 }"
             >{{ data[col] }}</span
           >
-          <span v-else class="cell-info w-2rem">{{ data.texts }}</span>
+          <span v-else class="cell-info">{{ data[col] }}</span>
         </template>
       </Column>
     </DataTable>

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { computed, ComputedRef, onMounted, ref } from 'vue';
 import { useGuidelinesStore } from '../store/guidelines';
 import LoadingSpinner from './LoadingSpinner.vue';
 import { buildFetchUrl, capitalize } from '../utils/helper/helper';
@@ -8,17 +8,30 @@ import DataTable from 'primevue/datatable';
 import { IGuidelines } from '../models/IGuidelines';
 import { CollectionAccessObject, CollectionProperty } from '../models/types';
 
-defineProps<{
+type CollectionTableEntry = {
+  [key: string | keyof CollectionProperty]: unknown;
+};
+
+const props = defineProps<{
   collections: CollectionAccessObject[] | null;
 }>();
 
 const { guidelines, getCollectionFields } = useGuidelinesStore();
-const columns = ref<CollectionProperty[]>([]);
+const columns = ref<string[]>([]);
+
+const tableData: ComputedRef<CollectionTableEntry[]> = computed(() => {
+  return props?.collections?.map(collection => {
+    return {
+      ...collection.collection.data,
+      texts: collection.texts.length,
+    };
+  });
+});
 
 onMounted(async (): Promise<void> => {
   await getGuidelines();
 
-  columns.value = getCollectionFields();
+  columns.value = [...getCollectionFields().map(f => f.name), 'texts'];
 });
 
 // TODO: getGuidelines exists in multiple components now, should be moved to a shared location
@@ -43,13 +56,14 @@ async function getGuidelines(): Promise<void> {
 
 <template>
   <div class="flex-grow-1 overflow-y-auto">
-    <LoadingSpinner v-if="!collections" />
+    <LoadingSpinner v-if="!tableData" />
     <!-- TODO: Fix sorting... -->
     <DataTable
       v-else
       scrollable
+      :rowClass="() => 'bitch'"
       scrollHeight="flex"
-      :value="collections"
+      :value="tableData"
       paginator
       :rows="10"
       :rowsPerPageOptions="[10, 20, 50, 100]"
@@ -63,26 +77,29 @@ async function getGuidelines(): Promise<void> {
     >
       <Column
         v-for="col of columns"
-        :key="col.name"
-        :field="col.name"
-        :header="capitalize(col.name)"
+        :key="col"
+        :field="col"
+        :header="capitalize(col)"
         sortable
+        :headerStyle="col === 'texts' ? `width: 5rem` : ''"
       >
         <template #body="{ data }">
           <!-- TODO: This should come from the configuration... -->
+          <!-- TODO: Bit hacky. Beautify? -->
           <a
-            v-if="col.name === 'label'"
+            v-if="col === 'label'"
             class="cell-link"
-            :href="'/collections/' + data.collection.data.uuid"
-            v-tooltip.hover.top="{ value: data.collection.data[col.name], showDelay: 0 }"
-            >{{ data.collection.data[col.name] }}</a
+            :href="'/collections/' + data.uuid"
+            v-tooltip.hover.top="{ value: data[col], showDelay: 0 }"
+            >{{ data[col] }}</a
           >
           <span
-            v-else
+            v-else-if="col !== 'texts'"
             class="cell-info"
-            v-tooltip.hover.top="{ value: data.collection.data[col.name], showDelay: 0 }"
-            >{{ data.collection.data[col.name] }}</span
+            v-tooltip.hover.top="{ value: data[col], showDelay: 0 }"
+            >{{ data[col] }}</span
           >
+          <span v-else class="cell-info w-2rem">{{ data.texts }}</span>
         </template>
       </Column>
     </DataTable>

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -31,7 +31,7 @@ const tableData: ComputedRef<CollectionTableEntry[]> = computed(() => {
 onMounted(async (): Promise<void> => {
   await getGuidelines();
 
-  columns.value = [...getCollectionFields().map(f => f.name), 'texts'];
+  columns.value = [...getCollectionFields('text').map(f => f.name), 'texts'];
 });
 
 // TODO: getGuidelines exists in multiple components now, should be moved to a shared location

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -5,12 +5,11 @@ import LoadingSpinner from './LoadingSpinner.vue';
 import { buildFetchUrl, capitalize } from '../utils/helper/helper';
 import Column from 'primevue/column';
 import DataTable from 'primevue/datatable';
-import ICollection from '../models/ICollection';
 import { IGuidelines } from '../models/IGuidelines';
-import { CollectionProperty } from '../models/types';
+import { CollectionAccessObject, CollectionProperty } from '../models/types';
 
 defineProps<{
-  collections: ICollection[] | null;
+  collections: CollectionAccessObject[] | null;
 }>();
 
 const { guidelines, getCollectionFields } = useGuidelinesStore();
@@ -45,6 +44,7 @@ async function getGuidelines(): Promise<void> {
 <template>
   <div class="flex-grow-1 overflow-y-auto">
     <LoadingSpinner v-if="!collections" />
+    <!-- TODO: Fix sorting... -->
     <DataTable
       v-else
       scrollable
@@ -70,18 +70,19 @@ async function getGuidelines(): Promise<void> {
       >
         <template #body="{ data }">
           <!-- TODO: This should come from the configuration... -->
+          <!-- TODO: the link creation works only when exactly ONE text is connected -> fix! -->
           <a
             v-if="col.name === 'label'"
             class="cell-link"
-            :href="'/texts/' + data.uuid"
-            v-tooltip.hover.top="{ value: data[col.name], showDelay: 0 }"
-            >{{ data[col.name] }}</a
+            :href="'/texts/' + data.texts[0].data.uuid"
+            v-tooltip.hover.top="{ value: data.collection.data[col.name], showDelay: 0 }"
+            >{{ data.collection.data[col.name] }}</a
           >
           <span
             v-else
             class="cell-info"
-            v-tooltip.hover.top="{ value: data[col.name], showDelay: 0 }"
-            >{{ data[col.name] }}</span
+            v-tooltip.hover.top="{ value: data.collection.data[col.name], showDelay: 0 }"
+            >{{ data.collection.data[col.name] }}</span
           >
         </template>
       </Column>

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -70,11 +70,10 @@ async function getGuidelines(): Promise<void> {
       >
         <template #body="{ data }">
           <!-- TODO: This should come from the configuration... -->
-          <!-- TODO: the link creation works only when exactly ONE text is connected -> fix! -->
           <a
             v-if="col.name === 'label'"
             class="cell-link"
-            :href="'/texts/' + data.texts[0].data.uuid"
+            :href="'/collections/' + data.collection.data.uuid"
             v-tooltip.hover.top="{ value: data.collection.data[col.name], showDelay: 0 }"
             >{{ data.collection.data[col.name] }}</a
           >

--- a/client/src/components/OverviewToolbar.vue
+++ b/client/src/components/OverviewToolbar.vue
@@ -108,7 +108,7 @@ function handleSearchInput(): void {
         </InputIcon>
         <InputText
           spellcheck="false"
-          placeholder="Filter texts by label"
+          placeholder="Filter Collections by label"
           v-model="searchInput"
           @input="handleSearchInput"
         />
@@ -119,22 +119,21 @@ function handleSearchInput(): void {
       <Button
         icon="pi pi-plus"
         aria-label="Submit"
-        label="Add text"
-        title="Add new text"
+        label="Add Collection"
+        title="Add new Collection"
         @click="showDialog"
       />
     </template>
   </Toolbar>
   <Dialog
     v-model:visible="dialogIsVisible"
-    header="Add new text"
     modal
     :closable="false"
     :close-on-escape="false"
     :style="{ width: '25rem' }"
   >
     <template #header>
-      <h2 class="w-full text-center m-0">Add new text</h2>
+      <h2 class="w-full text-center m-0">Add new Collection</h2>
     </template>
     <form @submit.prevent="createNewCollection">
       <div

--- a/client/src/models/ICollection.ts
+++ b/client/src/models/ICollection.ts
@@ -1,18 +1,8 @@
 export default interface ICollection {
   [keyof: string]: string | number;
-  doctype: string;
-  explicit: string;
-  folioEnd: string;
-  folioStart: string;
-  // guid: string;
-  incipit: string;
-  inscriptio: string;
   label: string;
-  normalizedLabel: string;
   receivedBy: string;
   sentBy: string;
   status: string;
-  textGuid: string;
   uuid: string;
-  websiteUrl: string;
 }

--- a/client/src/models/IGuidelines.ts
+++ b/client/src/models/IGuidelines.ts
@@ -18,4 +18,7 @@ export interface IGuidelines {
     properties: AnnotationProperty[];
     resources: AnnotationConfigResource[];
   };
+  texts: {
+    additionalLabels: string[];
+  };
 }

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -80,7 +80,7 @@ export type CharacterPostData = {
 
 export type Collection = {
   data: ICollection;
-  nodeLabel: string;
+  nodeLabels: string[];
 };
 
 export type CollectionAccessObject = {
@@ -128,7 +128,7 @@ export type StandoffJson = {
 };
 
 export type Text = {
-  nodeLabel: string;
+  nodeLabels: string[];
   data: IText;
 };
 

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -71,9 +71,9 @@ export type Character = {
 };
 
 export type CharacterPostData = {
-  collectionUuid: string;
   characters: ICharacter[];
   text: string;
+  textUuid: string;
   uuidEnd: string;
   uuidStart: string;
 };
@@ -81,6 +81,11 @@ export type CharacterPostData = {
 export type Collection = {
   data: ICollection;
   nodeLabel: string;
+};
+
+export type CollectionAccessObject = {
+  collection: Collection;
+  texts: Text;
 };
 
 export type CollectionProperty = {

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -116,3 +116,14 @@ export type StandoffJson = {
   annotations: StandoffAnnotation[];
   text: string;
 };
+
+export type Text = {
+  nodeLabel: string;
+  data: IText;
+};
+
+export type TextAccessObject = {
+  collection: Collection;
+  path: Record<string, any>[];
+  text: Text;
+};

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -97,6 +97,11 @@ export type CollectionProperty = {
   // options?: string[] /* Options if type is dropdown */;
 };
 
+export type CollectionPostData = {
+  data: CollectionAccessObject;
+  initialData: CollectionAccessObject;
+};
+
 export type HistoryStack = HistoryRecord[];
 
 export type HistoryRecord = {

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -134,6 +134,6 @@ export type Text = {
 
 export type TextAccessObject = {
   collection: Collection;
-  path: Record<string, any>[];
+  path: Text[] | Collection[];
   text: Text;
 };

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -85,7 +85,7 @@ export type Collection = {
 
 export type CollectionAccessObject = {
   collection: Collection;
-  texts: Text;
+  texts: Text[];
 };
 
 export type CollectionProperty = {

--- a/client/src/router.ts
+++ b/client/src/router.ts
@@ -1,9 +1,12 @@
 import { RouteRecordRaw, Router, createWebHistory, createRouter } from 'vue-router';
 import Overview from './views/Overview.vue';
 import Editor from './views/Editor.vue';
+import CollectionEntry from './views/CollectionEntry.vue';
 
 const routes: RouteRecordRaw[] = [
   { path: '/', component: Overview },
+  { path: '/collections', component: Overview },
+  { path: '/collections/:uuid', component: CollectionEntry },
   { path: '/texts/:uuid', component: Editor },
 ];
 

--- a/client/src/store/collection.ts
+++ b/client/src/store/collection.ts
@@ -4,18 +4,18 @@ import { Collection } from '../models/types';
 
 const collection = ref<ICollection>();
 const initialCollection = ref<ICollection>();
-const collectionNodeLabel = ref<string>();
+const collectionNodeLabels = ref<string[]>([]);
 
 function initializeCollection(newCollection: Collection): void {
   collection.value = newCollection.data;
-  collectionNodeLabel.value = newCollection.nodeLabel;
+  collectionNodeLabels.value = newCollection.nodeLabels;
   initialCollection.value = { ...newCollection.data };
 }
 export function useCollectionStore() {
   return {
     collection,
     initialCollection,
-    collectionNodeLabel,
+    collectionNodeLabels,
     initializeCollection,
   };
 }

--- a/client/src/store/editor.ts
+++ b/client/src/store/editor.ts
@@ -64,7 +64,7 @@ export function useEditorStore() {
   function hasUnsavedChanges(): boolean {
     // Compare text labels
     // TODO: This needs to be adjusted as soon as labels can be edited
-    if (!areSetsEqual(new Set(initialText.value.nodeLabel), new Set(text.value.nodeLabel))) {
+    if (!areSetsEqual(new Set(initialText.value.nodeLabels), new Set(text.value.nodeLabels))) {
       return true;
     }
 

--- a/client/src/store/editor.ts
+++ b/client/src/store/editor.ts
@@ -1,11 +1,11 @@
 import { ref } from 'vue';
 import { useAnnotationStore } from './annotations';
-import { useCollectionStore } from './collection';
 import { useCharactersStore } from './characters';
 import { areObjectsEqual, areSetsEqual } from '../utils/helper/helper';
 import { Annotation } from '../models/types';
+import { useTextStore } from './text';
 
-const { collection, initialCollection } = useCollectionStore();
+const { text, initialText } = useTextStore();
 const { snippetCharacters, initialSnippetCharacters } = useCharactersStore();
 const { annotations, initialAnnotations } = useAnnotationStore();
 
@@ -62,8 +62,9 @@ export function useEditorStore() {
   }
 
   function hasUnsavedChanges(): boolean {
-    // Compare collection properties
-    if (!areObjectsEqual(collection.value, initialCollection.value)) {
+    // Compare text labels
+    // TODO: This needs to be adjusted as soon as labels can be edited
+    if (!areSetsEqual(new Set(initialText.value.nodeLabel), new Set(text.value.nodeLabel))) {
       return true;
     }
 

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -53,12 +53,14 @@ export function useGuidelinesStore() {
   }
 
   /**
-   * Retrieves the collection fields for the 'text' collection.
+   * Retrieves field configuration of a collection of given type. Contains information about rendering behaviour as well as validation rules.
+   * Used for rendering data tables or input fields in forms.
    *
-   * @returns {CollectionProperty[]} An array of collection propertie configurations.
+   * @param {string} type - The type of the collection.
+   * @return {CollectionProperty[]} The field configurations for the collection type.
    */
-  function getCollectionFields(): CollectionProperty[] {
-    return guidelines.value.collections['text'].properties;
+  function getCollectionFields(type: string): CollectionProperty[] {
+    return guidelines.value.collections[type].properties;
   }
 
   /**

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -53,6 +53,16 @@ export function useGuidelinesStore() {
   }
 
   /**
+   * Retrieves the available labels that can be assigned to a no Text node.
+   *
+   * @return {string[]} The available labels.
+   */
+  function getAvailableTextLabels(): string[] {
+    console.log(guidelines.value);
+    return guidelines.value.texts.additionalLabels;
+  }
+
+  /**
    * Retrieves field configuration of a collection of given type. Contains information about rendering behaviour as well as validation rules.
    * Used for rendering data tables or input fields in forms.
    *
@@ -90,6 +100,7 @@ export function useGuidelinesStore() {
     guidelines,
     getAnnotationConfig,
     getAnnotationFields,
+    getAvailableTextLabels,
     getCollectionFields,
     initializeGuidelines,
   };

--- a/client/src/store/text.ts
+++ b/client/src/store/text.ts
@@ -7,13 +7,14 @@ const initialText = ref<Text>(null);
 const correspondingCollection = ref<Collection>(null);
 const path = ref<Text[] | Collection[]>([]);
 
-function initializeText(newText: TextAccessObject): void {
-  text.value = newText.text;
-  initialText.value = cloneDeep(newText.text);
-  correspondingCollection.value = newText.collection;
-  path.value = newText.path;
-}
 export function useTextStore() {
+  function initializeText(newText: TextAccessObject): void {
+    text.value = newText.text;
+    initialText.value = cloneDeep(newText.text);
+    correspondingCollection.value = newText.collection;
+    path.value = newText.path;
+  }
+
   return {
     correspondingCollection,
     initialText,

--- a/client/src/store/text.ts
+++ b/client/src/store/text.ts
@@ -1,0 +1,24 @@
+import { ref } from 'vue';
+import { Collection, Text, TextAccessObject } from '../models/types';
+import { cloneDeep } from '../utils/helper/helper';
+
+const text = ref<Text>(null);
+const initialText = ref<Text>(null);
+const correspondingCollection = ref<Collection>(null);
+const path = ref<Record<string, any>[]>([]);
+
+function initializeText(newText: TextAccessObject): void {
+  text.value = newText.text;
+  initialText.value = cloneDeep(newText.text);
+  correspondingCollection.value = newText.collection;
+  path.value = newText.path;
+}
+export function useTextStore() {
+  return {
+    correspondingCollection,
+    initialText,
+    path,
+    text,
+    initializeText,
+  };
+}

--- a/client/src/store/text.ts
+++ b/client/src/store/text.ts
@@ -5,7 +5,7 @@ import { cloneDeep } from '../utils/helper/helper';
 const text = ref<Text>(null);
 const initialText = ref<Text>(null);
 const correspondingCollection = ref<Collection>(null);
-const path = ref<Record<string, any>[]>([]);
+const path = ref<Text[] | Collection[]>([]);
 
 function initializeText(newText: TextAccessObject): void {
   text.value = newText.text;

--- a/client/src/utils/helper/helper.ts
+++ b/client/src/utils/helper/helper.ts
@@ -42,6 +42,7 @@ export function cloneDeep(json: Record<any, any>) {
  * @return {boolean} Returns true if the objects are equal, otherwise false.
  */
 export function areObjectsEqual(obj1: Record<string, any>, obj2: Record<string, any>): boolean {
+  // TODO: This function needs to be rewritten when there are more complex objects...
   const keys1: string[] = Object.keys(obj1);
   const keys2: string[] = Object.keys(obj2);
 
@@ -66,7 +67,7 @@ export function areObjectsEqual(obj1: Record<string, any>, obj2: Record<string, 
  * @param {Set<string>} setB - The second set to compare.
  * @return {boolean} Returns true if the sets are equal, otherwise false.
  */
-export function areSetsEqual(setA: Set<string>, setB: Set<string>) {
+export function areSetsEqual(setA: Set<string>, setB: Set<string>): boolean {
   if (setA.size !== setB.size) {
     return false;
   }

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -16,6 +16,8 @@ import Column from 'primevue/column';
 import DataTable from 'primevue/datatable';
 import InputText from 'primevue/inputtext';
 import MultiSelect from 'primevue/multiselect';
+import Splitter from 'primevue/splitter';
+import SplitterPanel from 'primevue/splitterpanel';
 import Tag from 'primevue/tag';
 import Toast from 'primevue/toast';
 import { ToastServiceMethods } from 'primevue/toastservice';
@@ -249,144 +251,151 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
         {{ collectionAccessObject?.collection.data.label }}
       </h2>
     </div>
-    <div class="flex-grow-1 flex">
-      <div class="properties-pane">
-        <h3 class="text-center">Properties</h3>
-        <form>
-          <div class="flex align-items-center gap-3 mb-3">
-            <InputText
-              id="uuid"
-              :disabled="true"
-              :value="collectionAccessObject.collection.data.uuid"
-              class="flex-auto w-full"
-              size="small"
-              spellcheck="false"
-            />
-            <Button
-              icon="pi pi-copy"
-              severity="secondary"
-              size="small"
-              aria-label="Copy UUID"
-              title="Copy UUID"
-              @click="handleCopy"
-            />
-          </div>
-          <div class="input-container" v-for="field in fields">
+    <Splitter style="height: 100%">
+      <SplitterPanel :size="10">
+        <div class="properties-pane w-full">
+          <h3 class="text-center">Properties</h3>
+          <form>
             <div class="flex align-items-center gap-3 mb-3">
-              <label :for="field.name" class="w-10rem font-semibold"
-                >{{ capitalize(field.name) }}
-              </label>
               <InputText
-                :id="field.name"
-                :disabled="mode === 'view' || !field.editable"
-                :required="field.required"
-                :invalid="field.required && !collectionAccessObject.collection.data[field.name]"
-                :key="field.name"
-                v-model="collectionAccessObject.collection.data[field.name] as string"
+                id="uuid"
+                :disabled="true"
+                :value="collectionAccessObject.collection.data.uuid"
                 class="flex-auto w-full"
+                size="small"
                 spellcheck="false"
               />
+              <Button
+                icon="pi pi-copy"
+                severity="secondary"
+                size="small"
+                aria-label="Copy UUID"
+                title="Copy UUID"
+                @click="handleCopy"
+              />
             </div>
-          </div>
-        </form>
-      </div>
-      <div class="texts-pane">
-        <h3 class="text-center">Texts</h3>
-        <div class="text-pane-content">
-          <DataTable
-            :value="tableData"
-            scrollable
-            scrollHeight="flex"
-            resizableColumns
-            rowHover
-            tableStyle="table-layout: fixed;"
-            size="small"
-          >
-            <Column field="labels" header="Labels" headerStyle="width: 15rem">
-              <template #body="{ data }">
-                <MultiSelect
-                  v-if="mode === 'edit'"
-                  v-model="
-                    collectionAccessObject.texts.find(t => t.data.uuid === data.uuid).nodeLabels
-                  "
-                  :options="allowedTextLabels"
-                  display="chip"
-                  placeholder="Select labels"
-                >
-                  <template #chip="{ value }">
-                    <Tag :value="value" severity="secondary" class="mr-1" />
-                  </template>
-                </MultiSelect>
-                <span v-else class="cell-info">
-                  <template v-for="label in data.labels">
-                    <Tag :value="label" severity="secondary" class="mr-1" />
-                  </template>
-                </span>
-              </template>
-            </Column>
-            <Column field="text" header="Text">
-              <template #body="{ data }">
-                <a class="cell-link" :href="'/texts/' + data.uuid">{{ data.text }}</a>
-              </template>
-            </Column>
-            <Column field="length" header="Length" headerStyle="width: 5rem">
-              <template #body="{ data }">
-                <span class="cell-info">{{ data.length.toLocaleString() }}</span>
-              </template>
-            </Column>
-            <Column field="actions" headerStyle="width: 5rem">
-              <template #body="{ data }">
-                <div class="flex">
-                  <div style="display: flex; flex-direction: column">
+            <div class="input-container" v-for="field in fields">
+              <div class="flex align-items-center gap-3 mb-3">
+                <label :for="field.name" class="w-10rem font-semibold"
+                  >{{ capitalize(field.name) }}
+                </label>
+                <InputText
+                  :id="field.name"
+                  :disabled="mode === 'view' || !field.editable"
+                  :required="field.required"
+                  :invalid="field.required && !collectionAccessObject.collection.data[field.name]"
+                  :key="field.name"
+                  v-model="collectionAccessObject.collection.data[field.name] as string"
+                  class="flex-auto w-full"
+                  spellcheck="false"
+                />
+              </div>
+            </div>
+          </form>
+        </div>
+      </SplitterPanel>
+      <SplitterPanel>
+        <div class="texts-pane w-full">
+          <h3 class="text-center">Texts</h3>
+          <div class="text-pane-content">
+            <DataTable
+              :value="tableData"
+              scrollable
+              scrollHeight="flex"
+              resizableColumns
+              rowHover
+              tableStyle="table-layout: fixed;"
+              size="small"
+            >
+              <Column field="labels" header="Labels" headerStyle="width: 15rem">
+                <template #body="{ data }">
+                  <!-- TODO: Remove filter. Can be fixed when Primevue version is upgraded -->
+                  <MultiSelect
+                    v-if="mode === 'edit'"
+                    v-model="
+                      collectionAccessObject.texts.find(t => t.data.uuid === data.uuid).nodeLabels
+                    "
+                    :options="allowedTextLabels"
+                    display="chip"
+                    placeholder="Select labels"
+                    :filter="false"
+                  >
+                    <template #chip="{ value }">
+                      <Tag :value="value" severity="secondary" class="mr-1" />
+                    </template>
+                  </MultiSelect>
+                  <span v-else class="cell-info">
+                    <template v-for="label in data.labels">
+                      <Tag :value="label" severity="secondary" class="mr-1" />
+                    </template>
+                  </span>
+                </template>
+              </Column>
+              <Column field="text" header="Text">
+                <template #body="{ data }">
+                  <a class="cell-link" :href="'/texts/' + data.uuid">{{ data.text }}</a>
+                </template>
+              </Column>
+              <Column field="length" header="Length" headerStyle="width: 5rem">
+                <template #body="{ data }">
+                  <span class="cell-info">{{ data.length.toLocaleString() }}</span>
+                </template>
+              </Column>
+              <Column field="actions" headerStyle="width: 5rem">
+                <template #body="{ data }">
+                  <div class="flex">
+                    <div style="display: flex; flex-direction: column">
+                      <Button
+                        v-if="mode === 'edit'"
+                        :disabled="
+                          collectionAccessObject.texts.findIndex(t => t.data.uuid === data.uuid) ===
+                          0
+                        "
+                        class="h-1rem"
+                        title="Move text up"
+                        severity="secondary"
+                        icon="pi pi-chevron-up"
+                        size="small"
+                        @click="shiftText(data.uuid, 'up')"
+                      /><Button
+                        v-if="mode === 'edit'"
+                        :disabled="
+                          collectionAccessObject.texts.findIndex(t => t.data.uuid === data.uuid) ===
+                          collectionAccessObject.texts.length - 1
+                        "
+                        class="h-1rem"
+                        title="Move text down"
+                        severity="secondary"
+                        icon="pi pi-chevron-down"
+                        size="small"
+                        @click="shiftText(data.uuid, 'down')"
+                      />
+                    </div>
                     <Button
                       v-if="mode === 'edit'"
-                      :disabled="
-                        collectionAccessObject.texts.findIndex(t => t.data.uuid === data.uuid) === 0
-                      "
-                      class="h-1rem"
-                      title="Move text up"
-                      severity="secondary"
-                      icon="pi pi-chevron-up"
+                      title="Delete text"
+                      severity="danger"
+                      icon="pi pi-trash"
                       size="small"
-                      @click="shiftText(data.uuid, 'up')"
-                    /><Button
-                      v-if="mode === 'edit'"
-                      :disabled="
-                        collectionAccessObject.texts.findIndex(t => t.data.uuid === data.uuid) ===
-                        collectionAccessObject.texts.length - 1
-                      "
-                      class="h-1rem"
-                      title="Move text down"
-                      severity="secondary"
-                      icon="pi pi-chevron-down"
-                      size="small"
-                      @click="shiftText(data.uuid, 'down')"
+                      @click="handleDeleteText(data.uuid)"
                     />
                   </div>
-                  <Button
-                    v-if="mode === 'edit'"
-                    title="Delete text"
-                    severity="danger"
-                    icon="pi pi-trash"
-                    size="small"
-                    @click="handleDeleteText(data.uuid)"
-                  />
-                </div>
-              </template>
-            </Column>
-          </DataTable>
-
-          <Button
-            v-show="mode === 'edit'"
-            label="Add new text"
-            title="Add new text to collection"
-            icon="pi pi-plus"
-            style="display: block; margin: 0 auto"
-            @click="handleAddNewText"
-          ></Button>
+                </template>
+              </Column>
+            </DataTable>
+            <Button
+              v-show="mode === 'edit'"
+              label="Add new text"
+              title="Add new text to collection"
+              icon="pi pi-plus"
+              style="display: block; margin: 0 auto"
+              @click="handleAddNewText"
+            ></Button>
+          </div>
         </div>
-      </div>
-    </div>
+      </SplitterPanel>
+    </Splitter>
+
     <div class="action-button-container flex justify-content-center gap-3 p-3">
       <Button
         v-if="mode === 'view'"
@@ -419,7 +428,6 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
 <style scoped>
 .properties-pane,
 .texts-pane {
-  outline: 1px solid green;
   padding: 1rem;
 }
 

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -324,9 +324,9 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               <template #body="{ data }">
                 <!-- TODO: This should come from the configuration... -->
                 <!-- TODO: Bit hacky. Beautify? -->
-                <!-- TODO: Selection is not applied to state, why? -->
                 <Select
                   v-if="col === 'label' && mode === 'edit'"
+                  showClear
                   v-model="
                     collectionAccessObject.texts.find(t => t.data.uuid === data.uuid).nodeLabel
                   "

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -89,8 +89,7 @@ async function getGuidelines(): Promise<void> {
 
 function handleAddNewText(): void {
   const newText: Text = {
-    // TODO: This is not good, fix
-    nodeLabels: ['Text'],
+    nodeLabels: [],
     data: {
       uuid: crypto.randomUUID(),
       text: '',

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { CollectionAccessObject } from '../models/types';
+import { buildFetchUrl } from '../utils/helper/helper';
+import { RouteLocationNormalizedLoaded, useRoute } from 'vue-router';
+import Card from 'primevue/card';
+import LoadingSpinner from '../components/LoadingSpinner.vue';
+
+const route: RouteLocationNormalizedLoaded = useRoute();
+const collectionUuid: string = route.params.uuid as string;
+
+const collectionAccessObject = ref<CollectionAccessObject | null>(null);
+
+onMounted(async (): Promise<void> => {
+  await getCollection();
+});
+
+async function getCollection(): Promise<void> {
+  try {
+    const url: string = buildFetchUrl(`/api/collections/${collectionUuid}`);
+
+    const response: Response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+
+    const fetchedCollectionAccessObject: CollectionAccessObject = await response.json();
+    collectionAccessObject.value = fetchedCollectionAccessObject;
+  } catch (error: unknown) {
+    console.error('Error fetching collection:', error);
+  }
+}
+</script>
+
+<template>
+  <LoadingSpinner v-if="!collectionAccessObject" />
+
+  <div v-else class="container flex flex-column h-screen m-auto">
+    You are seeing the collection with the UUID {{ collectionUuid }} and its texts :)
+    <Card>
+      <template #title
+        ><div>
+          {{ collectionAccessObject?.collection.data.label }}
+        </div></template
+      >
+      <template #content>
+        Collection data:
+        <p class="m-0">
+          {{ collectionAccessObject.collection.data }}
+        </p>
+        <div>
+          It has {{ collectionAccessObject.texts.length }} texts:
+          <div class="flex">
+            <div v-for="text in collectionAccessObject.texts" class="text-box">
+              {{ text.data }}
+            </div>
+          </div>
+        </div>
+      </template>
+    </Card>
+  </div>
+</template>
+
+<style scoped>
+.container {
+  width: 80%;
+  min-width: 800px;
+}
+
+.text-box {
+  width: 400px;
+  border: 2px solid grey;
+}
+</style>

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ComputedRef, onMounted, ref } from 'vue';
-import { RouteLocationNormalizedLoaded, useRoute } from 'vue-router';
+import { RouteLocationNormalizedLoaded, RouterLink, useRoute } from 'vue-router';
 import { useGuidelinesStore } from '../store/guidelines';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
 import { buildFetchUrl, capitalize, cloneDeep } from '../utils/helper/helper';
@@ -337,14 +337,14 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               </Column>
               <Column field="text" header="Text">
                 <template #body="{ data }">
-                  <a
+                  <RouterLink
                     class="cell-link block w-full"
-                    :href="`/texts/${data.uuid}`"
+                    :to="`/texts/${data.uuid}`"
                     title="Open Text in Editor"
                   >
                     <span v-if="data.text.length > 0">{{ data.text }}</span>
                     <i v-else>No text yet...</i>
-                  </a>
+                  </RouterLink>
                 </template>
               </Column>
               <Column field="length" header="Length" headerStyle="width: 5rem">

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -253,7 +253,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
     <Splitter style="height: 100%">
       <SplitterPanel :size="10">
         <div class="properties-pane w-full">
-          <h3 class="text-center">Properties</h3>
+          <h2 class="text-center">Properties</h2>
           <form>
             <div class="flex align-items-center gap-3 mb-3">
               <InputText
@@ -295,7 +295,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
       </SplitterPanel>
       <SplitterPanel>
         <div class="texts-pane w-full">
-          <h3 class="text-center">Texts</h3>
+          <h2 class="text-center">Texts ({{ collectionAccessObject.texts.length }})</h2>
           <div class="text-pane-content">
             <DataTable
               :value="tableData"
@@ -306,7 +306,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               tableStyle="table-layout: fixed;"
               size="small"
             >
-              <Column field="labels" header="Labels" headerStyle="width: 15rem">
+              <Column field="labels" header="Labels" headerStyle="width: 12rem">
                 <template #body="{ data }">
                   <!-- TODO: Remove filter. Can be fixed when Primevue version is upgraded -->
                   <MultiSelect
@@ -324,15 +324,27 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
                     </template>
                   </MultiSelect>
                   <span v-else class="cell-info">
-                    <template v-for="label in data.labels">
-                      <Tag :value="label" severity="secondary" class="mr-1" />
-                    </template>
+                    <div class="box flex" style="flex-wrap: wrap">
+                      <Tag
+                        v-for="label in data.labels"
+                        :value="label"
+                        severity="secondary"
+                        class="mr-1 mb-1 inline-block"
+                      />
+                    </div>
                   </span>
                 </template>
               </Column>
               <Column field="text" header="Text">
                 <template #body="{ data }">
-                  <a class="cell-link" :href="'/texts/' + data.uuid">{{ data.text }}</a>
+                  <a
+                    class="cell-link block w-full"
+                    :href="`/texts/${data.uuid}`"
+                    title="Open Text in Editor"
+                  >
+                    <span v-if="data.text.length > 0">{{ data.text }}</span>
+                    <i v-else>No text yet...</i>
+                  </a>
                 </template>
               </Column>
               <Column field="length" header="Length" headerStyle="width: 5rem">
@@ -340,7 +352,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
                   <span class="cell-info">{{ data.length.toLocaleString() }}</span>
                 </template>
               </Column>
-              <Column field="actions" headerStyle="width: 5rem">
+              <Column v-if="mode === 'edit'" field="actions" headerStyle="width: 5rem">
                 <template #body="{ data }">
                   <div class="flex">
                     <div style="display: flex; flex-direction: column">

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -13,6 +13,7 @@ import {
 } from '../models/types';
 import Button from 'primevue/button';
 import Column from 'primevue/column';
+import ConfirmPopup from 'primevue/confirmpopup';
 import DataTable from 'primevue/datatable';
 import InputText from 'primevue/inputtext';
 import MultiSelect from 'primevue/multiselect';
@@ -21,6 +22,7 @@ import SplitterPanel from 'primevue/splitterpanel';
 import Tag from 'primevue/tag';
 import Toast from 'primevue/toast';
 import { ToastServiceMethods } from 'primevue/toastservice';
+import { useConfirm } from 'primevue/useconfirm';
 import { useToast } from 'primevue/usetoast';
 
 type TextTableEntry = {
@@ -32,6 +34,7 @@ type TextTableEntry = {
 
 const route: RouteLocationNormalizedLoaded = useRoute();
 const toast: ToastServiceMethods = useToast();
+const confirm = useConfirm();
 const { guidelines, getAvailableTextLabels, initializeGuidelines } = useGuidelinesStore();
 
 const collectionUuid: string = route.params.uuid as string;
@@ -103,9 +106,28 @@ async function handleCopy(): Promise<void> {
 }
 
 async function handleDeleteText(uuid: string) {
-  collectionAccessObject.value.texts = collectionAccessObject.value.texts.filter(
-    (text: Text) => text.data.uuid !== uuid,
-  );
+  confirm.require({
+    target: event.currentTarget as HTMLButtonElement,
+    message: 'Do you want to delete this text?',
+    icon: 'pi pi-exclamation-triangle',
+    rejectProps: {
+      label: 'Cancel',
+      severity: 'secondary',
+      outlined: true,
+      title: 'Cancel',
+    },
+    acceptProps: {
+      label: 'Delete',
+      severity: 'danger',
+      title: 'Delete annotation',
+    },
+    accept: () => {
+      collectionAccessObject.value.texts = collectionAccessObject.value.texts.filter(
+        (text: Text) => text.data.uuid !== uuid,
+      );
+    },
+    reject: () => {},
+  });
 }
 
 async function handleCancelChanges(): Promise<void> {
@@ -234,6 +256,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
   <LoadingSpinner v-if="!collectionAccessObject" />
   <div v-else class="container h-screen m-auto flex flex-column">
     <Toast />
+    <ConfirmPopup />
     <RouterLink to="/" class="pl-2 pt-2">
       <Button
         icon="pi pi-home"

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -222,6 +222,25 @@ async function getCollection(): Promise<void> {
     console.error('Error fetching collection:', error);
   }
 }
+
+function shiftText(textUuid: string, direction: 'up' | 'down') {
+  const texts: Text[] = collectionAccessObject.value.texts;
+  const text: Text = texts.find(t => t.data.uuid === textUuid);
+  const index: number = texts.indexOf(text);
+
+  const isFirst: boolean = index === 0;
+  const isLast: boolean = index === texts.length - 1;
+
+  if ((isFirst && direction === 'up') || (isLast && direction === 'down')) {
+    return;
+  }
+
+  const swapIndex = direction === 'up' ? index - 1 : index + 1;
+
+  [texts[index], texts[swapIndex]] = [texts[swapIndex], texts[index]];
+
+  console.log(text, index);
+}
 </script>
 
 <template>
@@ -323,16 +342,44 @@ async function getCollection(): Promise<void> {
                 <span v-else class="cell-info">{{ data[col] }}</span>
               </template>
             </Column>
-            <Column headerStyle="width: 5rem">
+            <Column headerStyle="width: 10rem">
               <template #body="{ data }">
-                <Button
-                  v-if="mode === 'edit'"
-                  title="Delete text"
-                  severity="danger"
-                  icon="pi pi-trash"
-                  size="small"
-                  @click="handleDeleteText(data.uuid)"
-                />
+                <div class="flex">
+                  <div style="display: flex; flex-direction: column">
+                    <Button
+                      v-if="mode === 'edit'"
+                      :disabled="
+                        collectionAccessObject.texts.findIndex(t => t.data.uuid === data.uuid) === 0
+                      "
+                      class="h-1rem"
+                      title="Move text up"
+                      severity="secondary"
+                      icon="pi pi-chevron-up"
+                      size="small"
+                      @click="shiftText(data.uuid, 'up')"
+                    /><Button
+                      v-if="mode === 'edit'"
+                      :disabled="
+                        collectionAccessObject.texts.findIndex(t => t.data.uuid === data.uuid) ===
+                        collectionAccessObject.texts.length - 1
+                      "
+                      class="h-1rem"
+                      title="Move text down"
+                      severity="secondary"
+                      icon="pi pi-chevron-down"
+                      size="small"
+                      @click="shiftText(data.uuid, 'down')"
+                    />
+                  </div>
+                  <Button
+                    v-if="mode === 'edit'"
+                    title="Delete text"
+                    severity="danger"
+                    icon="pi pi-trash"
+                    size="small"
+                    @click="handleDeleteText(data.uuid)"
+                  />
+                </div>
               </template>
             </Column>
           </DataTable>

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -234,20 +234,37 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
   <LoadingSpinner v-if="!collectionAccessObject" />
   <div v-else class="container h-screen m-auto flex flex-column">
     <Toast />
+    <RouterLink to="/" class="pl-2 pt-2">
+      <Button
+        icon="pi pi-home"
+        aria-label="Home"
+        class="w-2rem h-2rem"
+        title="Go to overview"
+      ></Button>
+    </RouterLink>
     <div class="header flex align-items-center justify-content-center gap-3">
-      <RouterLink to="/">
-        <Button
-          icon="pi pi-home"
-          aria-label="Home"
-          class="w-2rem h-2rem"
-          title="Go to overview"
-        ></Button>
-      </RouterLink>
-      <h2 class="info">
+      <h2 class="info mt-0">
         {{ collectionAccessObject?.collection.data.label }}
       </h2>
     </div>
-    <Splitter class="flex-grow-1 overflow-y-auto">
+    <Splitter
+      class="flex-grow-1 overflow-y-auto"
+      :pt="{
+        gutter: {
+          style: {
+            width: '4px',
+          },
+        },
+        gutterHandle: {
+          style: {
+            width: '6px',
+            position: 'absolute',
+            backgroundColor: 'darkgray',
+            height: '40px',
+          },
+        },
+      }"
+    >
       <SplitterPanel :size="10" class="overflow-y-auto">
         <div class="properties-pane w-full">
           <h2 class="text-center">Properties</h2>
@@ -349,9 +366,9 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
                   <span class="cell-info">{{ data.length.toLocaleString() }}</span>
                 </template>
               </Column>
-              <Column v-if="mode === 'edit'" field="actions" headerStyle="width: 5rem">
+              <Column v-if="mode === 'edit'" field="actions" headerStyle="width: 7rem">
                 <template #body="{ data }">
-                  <div class="flex">
+                  <div class="flex gap-2">
                     <div style="display: flex; flex-direction: column">
                       <Button
                         v-if="mode === 'edit'"

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -1,18 +1,96 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
-import { CollectionAccessObject } from '../models/types';
-import { buildFetchUrl } from '../utils/helper/helper';
+import { computed, ComputedRef, onMounted, ref } from 'vue';
+import { CollectionAccessObject, CollectionProperty } from '../models/types';
 import { RouteLocationNormalizedLoaded, useRoute } from 'vue-router';
-import Button from 'primevue/button';
-import Card from 'primevue/card';
+import { useGuidelinesStore } from '../store/guidelines';
+import { buildFetchUrl, capitalize } from '../utils/helper/helper';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
+import { IGuidelines } from '../models/IGuidelines';
+import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
+import Toast from 'primevue/toast';
+import { ToastServiceMethods } from 'primevue/toastservice';
+import { useToast } from 'primevue/usetoast';
 
 const route: RouteLocationNormalizedLoaded = useRoute();
+
 const collectionUuid: string = route.params.uuid as string;
 
 const collectionAccessObject = ref<CollectionAccessObject | null>(null);
+const mode = ref<'view' | 'edit'>('view');
+const asyncOperationRunning = ref<boolean>(false);
+
+const toast: ToastServiceMethods = useToast();
+const { guidelines, initializeGuidelines } = useGuidelinesStore();
+
+// TODO: Still a workaround, should be mady dynamic.
+const fields: ComputedRef<CollectionProperty[]> = computed(() => {
+  if (collectionAccessObject.value.collection.nodeLabel === 'Letter') {
+    return guidelines.value ? guidelines.value.collections['text'].properties : [];
+  } else {
+    return guidelines.value ? guidelines.value.collections['comment'].properties : [];
+  }
+});
+
+async function getGuidelines(): Promise<void> {
+  try {
+    const url: string = buildFetchUrl(`/api/guidelines`);
+
+    const response: Response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+
+    const fetchedGuidelines: IGuidelines = await response.json();
+
+    initializeGuidelines(fetchedGuidelines);
+  } catch (error: unknown) {
+    console.error('Error fetching guidelines:', error);
+  }
+}
+
+async function handleSaveChanges(): Promise<void> {
+  // return;
+  // if (!hasUnsavedChanges()) {
+  //   console.log('no changes made, no request needed');
+  //   return;
+  // }
+
+  asyncOperationRunning.value = true;
+
+  try {
+    asyncOperationRunning.value = false;
+    toggleEditMode();
+    showMessage('success');
+  } catch (error: unknown) {
+    showMessage('error', error as Error);
+    console.error('Error updating collection:', error);
+  } finally {
+    asyncOperationRunning.value = false;
+  }
+}
+
+async function handleCancelChanges(): Promise<void> {
+  // TODO: Set initial data again...
+  toggleEditMode();
+}
+
+function showMessage(result: 'success' | 'error', error?: Error) {
+  toast.add({
+    severity: result,
+    summary: result === 'success' ? 'Changes saved successfully' : 'Error saving changes',
+    detail: error?.message ?? '',
+    life: 2000,
+  });
+}
+
+function toggleEditMode(): void {
+  mode.value = mode.value === 'view' ? 'edit' : 'view';
+}
 
 onMounted(async (): Promise<void> => {
+  await getGuidelines();
   await getCollection();
 });
 
@@ -36,8 +114,8 @@ async function getCollection(): Promise<void> {
 
 <template>
   <LoadingSpinner v-if="!collectionAccessObject" />
-
-  <div v-else class="container h-screen m-auto">
+  <div v-else class="container h-screen m-auto flex flex-column">
+    <Toast />
     <div class="header flex align-items-center justify-content-center gap-3">
       <RouterLink to="/">
         <Button
@@ -47,31 +125,76 @@ async function getCollection(): Promise<void> {
           title="Go to overview"
         ></Button>
       </RouterLink>
-      <h3 class="info">
-        You are seeing the collection with the UUID {{ collectionUuid }} and its texts :)
-      </h3>
+      <h2 class="info">
+        {{ collectionAccessObject?.collection.data.label }}
+      </h2>
     </div>
-    <Card>
-      <template #title
-        ><div>
-          {{ collectionAccessObject?.collection.data.label }}
-        </div></template
-      >
-      <template #content>
-        Collection data:
-        <p class="m-0">
-          {{ collectionAccessObject.collection.data }}
-        </p>
-        <div>
-          It has {{ collectionAccessObject.texts.length }} texts:
-          <div class="flex">
+    <div class="flex flex-grow-1">
+      <div class="properties-pane">
+        <h3 class="text-center">Properties</h3>
+        <form>
+          <div class="input-container" v-for="field in fields">
+            <div class="flex align-items-center gap-3 mb-3">
+              <label :for="field.name" class="w-10rem font-semibold"
+                >{{ capitalize(field.name) }}
+              </label>
+              <InputText
+                :id="field.name"
+                :disabled="!field.editable"
+                :required="field.required"
+                :invalid="field.required && !collectionAccessObject.collection.data[field.name]"
+                :key="field.name"
+                v-model="collectionAccessObject.collection.data[field.name] as string"
+                class="flex-auto w-full"
+                spellcheck="false"
+              />
+            </div>
+          </div>
+        </form>
+      </div>
+      <div class="texts-pane">
+        <h3 class="text-center">Texts</h3>
+        <div class="text-pane-content">
+          <div class="scrollbox">
             <div v-for="text in collectionAccessObject.texts" class="text-box">
               <a :href="`/texts/${text.data.uuid}`"> {{ text.data.text.slice(0, 100) }}... </a>
             </div>
           </div>
+          <Button
+            label="Add new text"
+            title="Add new text to collection"
+            icon="pi pi-plus"
+            style="display: block; margin: 0 auto"
+          ></Button>
         </div>
-      </template>
-    </Card>
+      </div>
+    </div>
+    <div class="action-button-container flex justify-content-center gap-3 p-3">
+      <Button
+        v-if="mode === 'view'"
+        severity="contrast"
+        aria-label="Edit collection"
+        title="Edit collection"
+        icon="pi pi-pencil"
+        label="Edit"
+        @click="toggleEditMode"
+      />
+      <Button
+        v-if="mode === 'edit'"
+        aria-label="Save changes"
+        title="Save changes"
+        label="Save"
+        @click="handleSaveChanges"
+      />
+      <Button
+        v-if="mode === 'edit'"
+        severity="secondary"
+        title="Discard changes"
+        aria-label="Cancel changes"
+        label="Cancel"
+        @click="handleCancelChanges"
+      />
+    </div>
   </div>
 </template>
 
@@ -79,6 +202,12 @@ async function getCollection(): Promise<void> {
 .container {
   width: 80%;
   min-width: 800px;
+}
+
+.properties-pane,
+.texts-pane {
+  outline: 1px solid green;
+  padding: 1rem;
 }
 
 .text-box {

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -3,6 +3,7 @@ import { onMounted, ref } from 'vue';
 import { CollectionAccessObject } from '../models/types';
 import { buildFetchUrl } from '../utils/helper/helper';
 import { RouteLocationNormalizedLoaded, useRoute } from 'vue-router';
+import Button from 'primevue/button';
 import Card from 'primevue/card';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
 
@@ -36,8 +37,20 @@ async function getCollection(): Promise<void> {
 <template>
   <LoadingSpinner v-if="!collectionAccessObject" />
 
-  <div v-else class="container flex flex-column h-screen m-auto">
-    You are seeing the collection with the UUID {{ collectionUuid }} and its texts :)
+  <div v-else class="container h-screen m-auto">
+    <div class="header flex align-items-center justify-content-center gap-3">
+      <RouterLink to="/">
+        <Button
+          icon="pi pi-home"
+          aria-label="Home"
+          class="w-2rem h-2rem"
+          title="Go to overview"
+        ></Button>
+      </RouterLink>
+      <h3 class="info">
+        You are seeing the collection with the UUID {{ collectionUuid }} and its texts :)
+      </h3>
+    </div>
     <Card>
       <template #title
         ><div>
@@ -53,7 +66,7 @@ async function getCollection(): Promise<void> {
           It has {{ collectionAccessObject.texts.length }} texts:
           <div class="flex">
             <div v-for="text in collectionAccessObject.texts" class="text-box">
-              {{ text.data }}
+              <a :href="`/texts/${text.data.uuid}`"> {{ text.data.text.slice(0, 100) }}... </a>
             </div>
           </div>
         </div>
@@ -69,7 +82,6 @@ async function getCollection(): Promise<void> {
 }
 
 .text-box {
-  width: 400px;
   border: 2px solid grey;
 }
 </style>

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -255,6 +255,9 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
 <template>
   <LoadingSpinner v-if="!collectionAccessObject" />
   <div v-else class="container h-screen m-auto flex flex-column">
+    <div class="absolute overlay w-full h-full" v-if="asyncOperationRunning">
+      <LoadingSpinner />
+    </div>
     <Toast />
     <ConfirmPopup />
     <RouterLink to="/" class="pl-2 pt-2">
@@ -456,6 +459,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
       />
       <Button
         v-if="mode === 'edit'"
+        :loading="asyncOperationRunning"
         aria-label="Save changes"
         title="Save changes"
         label="Save"
@@ -474,6 +478,10 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
 </template>
 
 <style scoped>
+.overlay {
+  z-index: 99999;
+}
+
 .properties-pane,
 .texts-pane {
   padding: 1rem;

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -232,7 +232,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
 
 <template>
   <LoadingSpinner v-if="!collectionAccessObject" />
-  <div v-else class="container justify-content-stretch h-screen m-auto flex flex-column">
+  <div v-else class="container h-screen m-auto flex flex-column">
     <Toast />
     <div class="header flex align-items-center justify-content-center gap-3">
       <RouterLink to="/">
@@ -247,8 +247,8 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
         {{ collectionAccessObject?.collection.data.label }}
       </h2>
     </div>
-    <Splitter style="height: 100%">
-      <SplitterPanel :size="10">
+    <Splitter class="flex-grow-1 overflow-y-auto">
+      <SplitterPanel :size="10" class="overflow-y-auto">
         <div class="properties-pane w-full">
           <h2 class="text-center">Properties</h2>
           <form>
@@ -290,7 +290,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
           </form>
         </div>
       </SplitterPanel>
-      <SplitterPanel>
+      <SplitterPanel class="overflow-y-auto">
         <div class="texts-pane w-full">
           <h2 class="text-center">Texts ({{ collectionAccessObject.texts.length }})</h2>
           <div class="text-pane-content">

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -32,7 +32,7 @@ type TextTableEntry = {
 
 const route: RouteLocationNormalizedLoaded = useRoute();
 const toast: ToastServiceMethods = useToast();
-const { guidelines, initializeGuidelines } = useGuidelinesStore();
+const { guidelines, getAvailableTextLabels, initializeGuidelines } = useGuidelinesStore();
 
 const collectionUuid: string = route.params.uuid as string;
 
@@ -41,8 +41,7 @@ const initialCollectionAccessObject = ref<CollectionAccessObject | null>(null);
 const mode = ref<'view' | 'edit'>('view');
 const asyncOperationRunning = ref<boolean>(false);
 
-// TODO: Make dynamic (guidelines)
-const allowedTextLabels = ['Comment', 'Normal'];
+const availableTextLabels = computed(getAvailableTextLabels);
 
 // TODO: Still a workaround, should be mady dynamic.
 const fields: ComputedRef<CollectionProperty[]> = computed(() => {
@@ -228,8 +227,6 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
   const swapIndex = direction === 'up' ? index - 1 : index + 1;
 
   [texts[index], texts[swapIndex]] = [texts[swapIndex], texts[index]];
-
-  console.log(text, index);
 }
 </script>
 
@@ -314,7 +311,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
                     v-model="
                       collectionAccessObject.texts.find(t => t.data.uuid === data.uuid).nodeLabels
                     "
-                    :options="allowedTextLabels"
+                    :options="availableTextLabels"
                     display="chip"
                     placeholder="Select labels"
                     :filter="false"

--- a/client/src/views/Editor.vue
+++ b/client/src/views/Editor.vue
@@ -83,7 +83,7 @@ const isValidText = ref<boolean>(false);
 const asyncOperationRunning = ref<boolean>(false);
 
 const { hasUnsavedChanges, resetEditor } = useEditorStore();
-const { text, initialText, path, initializeText } = useTextStore();
+const { text, initialText, initializeText } = useTextStore();
 const {
   afterEndIndex,
   beforeStartIndex,

--- a/client/src/views/Overview.vue
+++ b/client/src/views/Overview.vue
@@ -7,9 +7,10 @@ import OverviewToolbar from '../components/OverviewToolbar.vue';
 import OverviewCollectionTable from '../components/OverviewCollectionTable.vue';
 import ICollection from '../models/ICollection';
 import { buildFetchUrl } from '../utils/helper/helper';
+import { CollectionAccessObject } from '../models/types';
 
-const collections = ref<ICollection[] | null>(null);
-const filteredCollections = ref<ICollection[] | null>(null);
+const collections = ref<CollectionAccessObject[] | null>(null);
+const filteredCollections = ref<CollectionAccessObject[] | null>(null);
 const searchInput = ref<string>('');
 
 const toast: ToastServiceMethods = useToast();
@@ -36,13 +37,13 @@ async function getCollections(): Promise<void> {
       throw new Error('Network response was not ok');
     }
 
-    const fetchedCollections: ICollection[] = await response.json();
+    const fetchedCollections: CollectionAccessObject[] = await response.json();
 
-    fetchedCollections.sort((a: ICollection, b: ICollection) => {
-      if (a.label.toLowerCase() < b.label.toLowerCase()) {
+    fetchedCollections.sort((a: CollectionAccessObject, b: CollectionAccessObject) => {
+      if (a.collection.data.label.toLowerCase() < b.collection.data.label.toLowerCase()) {
         return -1;
       }
-      if (a.label.toLowerCase() > b.label.toLowerCase()) {
+      if (a.collection.data.label.toLowerCase() > b.collection.data.label.toLowerCase()) {
         return 1;
       }
       return 0;
@@ -55,8 +56,8 @@ async function getCollections(): Promise<void> {
 }
 
 function filterCollections(): void {
-  filteredCollections.value = collections.value.filter((c: ICollection) => {
-    return c.label.toLowerCase().includes(searchInput.value);
+  filteredCollections.value = collections.value.filter((c: CollectionAccessObject) => {
+    return c.collection.data.label.toLowerCase().includes(searchInput.value);
   });
 }
 

--- a/client/src/views/Overview.vue
+++ b/client/src/views/Overview.vue
@@ -84,7 +84,7 @@ function showMessage(operation: 'created' | 'deleted', detail?: string): void {
   <div class="container flex flex-column h-screen m-auto">
     <Toast />
 
-    <h1 class="text-center text-5xl line-height-2">Texts</h1>
+    <h1 class="text-center text-5xl line-height-2">Collections</h1>
 
     <OverviewToolbar
       @collection-created="handleCollectionCreation"
@@ -92,7 +92,9 @@ function showMessage(operation: 'created' | 'deleted', detail?: string): void {
     />
 
     <div class="counter text-right pt-2 pb-3">
-      <strong class="text-base">{{ collections ? collections.length : 0 }} texts in total</strong>
+      <strong class="text-base"
+        >{{ collections ? collections.length : 0 }} Collections in total</strong
+      >
     </div>
 
     <OverviewCollectionTable :collections="filteredCollections" />

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -87,9 +87,10 @@ services:
    NEO4J_server_https_listen__address: '0.0.0.0:7473'
    #NEO4J_server_bolt_advertised__address: '${APP_HOST}:${APP_PORT}'
    apoc.initializer.neo4j.0: CREATE CONSTRAINT collection_uuid IF NOT EXISTS FOR (c:Collection) REQUIRE c.uuid IS UNIQUE
-   apoc.initializer.neo4j.1: CREATE CONSTRAINT character_uuid IF NOT EXISTS FOR (ch:Character) REQUIRE ch.uuid IS UNIQUE
-   apoc.initializer.neo4j.2: CREATE CONSTRAINT annotation_uuid IF NOT EXISTS FOR (a:Annotation) REQUIRE a.uuid IS UNIQUE
-   apoc.initializer.neo4j.3: CREATE CONSTRAINT entity_uuid IF NOT EXISTS FOR (e:Entity) REQUIRE e.uuid IS UNIQUE
+   apoc.initializer.neo4j.1: CREATE CONSTRAINT text_uuid IF NOT EXISTS FOR (t:Text) REQUIRE t.uuid IS UNIQUE
+   apoc.initializer.neo4j.2: CREATE CONSTRAINT character_uuid IF NOT EXISTS FOR (ch:Character) REQUIRE ch.uuid IS UNIQUE
+   apoc.initializer.neo4j.3: CREATE CONSTRAINT annotation_uuid IF NOT EXISTS FOR (a:Annotation) REQUIRE a.uuid IS UNIQUE
+   apoc.initializer.neo4j.4: CREATE CONSTRAINT entity_uuid IF NOT EXISTS FOR (e:Entity) REQUIRE e.uuid IS UNIQUE
 
   healthcheck:
    test: /var/lib/neo4j/bin/cypher-shell -a neo4j+ssc://localhost -u ${NEO4J_USER} -p ${NEO4J_PW} "show databases;"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
    NEO4J_AUTH: ${NEO4J_USER}/${NEO4J_PW}
    NEO4J_PLUGINS: '["apoc", "apoc-extended"]'
    apoc.initializer.neo4j.0: CREATE CONSTRAINT collection_uuid IF NOT EXISTS FOR (c:Collection) REQUIRE c.uuid IS UNIQUE
-   apoc.initializer.neo4j.1: CREATE CONSTRAINT character_uuid IF NOT EXISTS FOR (ch:Character) REQUIRE ch.uuid IS UNIQUE
-   apoc.initializer.neo4j.2: CREATE CONSTRAINT annotation_uuid IF NOT EXISTS FOR (a:Annotation) REQUIRE a.uuid IS UNIQUE
-   apoc.initializer.neo4j.3: CREATE CONSTRAINT entity_uuid IF NOT EXISTS FOR (e:Entity) REQUIRE e.uuid IS UNIQUE
+   apoc.initializer.neo4j.1: CREATE CONSTRAINT text_uuid IF NOT EXISTS FOR (t:Text) REQUIRE t.uuid IS UNIQUE
+   apoc.initializer.neo4j.2: CREATE CONSTRAINT character_uuid IF NOT EXISTS FOR (ch:Character) REQUIRE ch.uuid IS UNIQUE
+   apoc.initializer.neo4j.3: CREATE CONSTRAINT annotation_uuid IF NOT EXISTS FOR (a:Annotation) REQUIRE a.uuid IS UNIQUE
+   apoc.initializer.neo4j.4: CREATE CONSTRAINT entity_uuid IF NOT EXISTS FOR (e:Entity) REQUIRE e.uuid IS UNIQUE

--- a/server/src/config/guidelines.json
+++ b/server/src/config/guidelines.json
@@ -1,4 +1,7 @@
 {
+  "texts": {
+    "additionalLabels": ["CommentText", "LetterText"]
+  },
   "collections": {
     "text": {
       "additionalLabel": "Letter",
@@ -7,7 +10,7 @@
           "name": "label",
           "type": "text",
           "required": true,
-          "editable": false,
+          "editable": true,
           "visible": false
         },
         {

--- a/server/src/models/ICollection.ts
+++ b/server/src/models/ICollection.ts
@@ -1,17 +1,8 @@
 export default interface ICollection {
-  doctype: string;
-  explicit: string;
-  folioEnd: string;
-  folioStart: string;
-  // guid: string;
-  incipit: string;
-  inscriptio: string;
+  [keyof: string]: string | number;
   label: string;
-  normalizedLabel: string;
   receivedBy: string;
   sentBy: string;
   status: string;
-  textGuid: string;
   uuid: string;
-  websiteUrl: string;
 }

--- a/server/src/models/IGuidelines.ts
+++ b/server/src/models/IGuidelines.ts
@@ -18,4 +18,7 @@ export interface IGuidelines {
     properties: AnnotationProperty[];
     resources: AnnotationConfigResource[];
   };
+  texts: {
+    additionalLabels: string[];
+  };
 }

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -97,6 +97,11 @@ export type CollectionProperty = {
   // options?: string[] /* Options if type is dropdown */;
 };
 
+export type CollectionPostData = {
+  data: CollectionAccessObject;
+  initialData: CollectionAccessObject;
+};
+
 export type MalformedAnnotation = {
   reason: 'indexOutOfBounds' | 'unconfiguredType';
   data: StandoffAnnotation;

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -80,7 +80,7 @@ export type CharacterPostData = {
 
 export type Collection = {
   data: ICollection;
-  nodeLabel: string;
+  nodeLabels: string[];
 };
 
 export type CollectionAccessObject = {
@@ -121,7 +121,7 @@ export type StandoffJson = {
 };
 
 export type Text = {
-  nodeLabel: string;
+  nodeLabels: string[];
   data: IText;
 };
 

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -71,15 +71,21 @@ export type Character = {
 };
 
 export type CharacterPostData = {
-  collectionUuid: string;
-  uuidStart: string;
-  uuidEnd: string;
   characters: ICharacter[];
+  text: string;
+  textUuid: string;
+  uuidEnd: string;
+  uuidStart: string;
 };
 
 export type Collection = {
   data: ICollection;
   nodeLabel: string;
+};
+
+export type CollectionAccessObject = {
+  collection: Collection;
+  texts: Text;
 };
 
 export type CollectionProperty = {

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -108,3 +108,14 @@ export type StandoffJson = {
   annotations: StandoffAnnotation[];
   text: string;
 };
+
+export type Text = {
+  nodeLabel: string;
+  data: IText;
+};
+
+export type TextAccessObject = {
+  collection: Collection;
+  path: Record<string, any>[];
+  text: Text;
+};

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -85,7 +85,7 @@ export type Collection = {
 
 export type CollectionAccessObject = {
   collection: Collection;
-  texts: Text;
+  texts: Text[];
 };
 
 export type CollectionProperty = {

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -127,6 +127,6 @@ export type Text = {
 
 export type TextAccessObject = {
   collection: Collection;
-  path: Record<string, any>[];
+  path: Text[] | Collection[];
   text: Text;
 };

--- a/server/src/routes/annotations.routes.ts
+++ b/server/src/routes/annotations.routes.ts
@@ -8,10 +8,10 @@ const router: Router = express.Router({ mergeParams: true });
 const annotationService: AnnotationService = new AnnotationService();
 
 router.get('/', async (req: Request, res: Response, next: NextFunction) => {
-  const collectionUuid: string = req.params.uuid;
+  const textUuid: string = req.params.uuid;
 
   try {
-    const annotations: AnnotationData[] = await annotationService.getAnnotations(collectionUuid);
+    const annotations: AnnotationData[] = await annotationService.getAnnotations(textUuid);
 
     res.status(200).json(annotations);
   } catch (error: unknown) {
@@ -20,12 +20,12 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
 });
 
 router.post('/', async (req: Request, res: Response, next: NextFunction) => {
-  const collectionUuid: string = req.params.uuid;
+  const textUuid: string = req.params.uuid;
   const annotations = req.body;
 
   try {
     const updatedAnnotations: IAnnotation[] = await annotationService.saveAnnotations(
-      collectionUuid,
+      textUuid,
       annotations as Annotation[],
     );
 

--- a/server/src/routes/characters.routes.ts
+++ b/server/src/routes/characters.routes.ts
@@ -8,10 +8,10 @@ const router: Router = express.Router({ mergeParams: true });
 const characterService: CharacterService = new CharacterService();
 
 router.get('/', async (req: Request, res: Response, next: NextFunction) => {
-  const collectionUuid: string = req.params.uuid;
+  const textUuid: string = req.params.uuid;
 
   try {
-    const characters: Character[] = await characterService.getCharacters(collectionUuid);
+    const characters: Character[] = await characterService.getCharacters(textUuid);
 
     res.status(200).json(characters);
   } catch (error: unknown) {
@@ -20,13 +20,13 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
 });
 
 router.post('/', async (req: Request, res: Response, next: NextFunction) => {
-  const collectionUuid: string = req.params.uuid;
+  const textUuid: string = req.params.uuid;
 
   const { uuidStart, uuidEnd, characters, text } = req.body;
 
   try {
     const updatedCharacters: ICharacter[] = await characterService.saveCharacters(
-      collectionUuid,
+      textUuid,
       uuidStart,
       uuidEnd,
       characters,

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -18,7 +18,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
     const additionalLabel = guidelines.collections['text'].additionalLabel;
 
     const collections: CollectionAccessObject[] =
-      await collectionService.getCollectionsWithText(additionalLabel);
+      await collectionService.getCollectionsWithTexts(additionalLabel);
 
     res.status(200).json(collections);
   } catch (error: unknown) {

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -5,7 +5,7 @@ import CollectionService from '../services/collection.service.js';
 import GuidelinesService from '../services/guidelines.service.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
-import { Collection, CollectionAccessObject, CollectionPostData } from '../models/types.js';
+import { CollectionAccessObject, CollectionPostData } from '../models/types.js';
 
 const router: Router = express.Router({ mergeParams: true });
 

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -5,7 +5,7 @@ import CollectionService from '../services/collection.service.js';
 import GuidelinesService from '../services/guidelines.service.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
-import { Collection, CollectionAccessObject } from '../models/types.js';
+import { Collection, CollectionAccessObject, CollectionPostData } from '../models/types.js';
 
 const router: Router = express.Router({ mergeParams: true });
 
@@ -59,7 +59,7 @@ router.get('/:uuid', async (req: Request, res: Response, next: NextFunction) => 
 
 router.post('/:uuid', async (req: Request, res: Response, next: NextFunction) => {
   const uuid: string = req.params.uuid;
-  const data: Record<string, string> = req.body;
+  const data: CollectionPostData = req.body;
 
   try {
     const collection: ICollection = await collectionService.updateCollection(uuid, data);

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -5,7 +5,7 @@ import CollectionService from '../services/collection.service.js';
 import GuidelinesService from '../services/guidelines.service.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
-import { Collection } from '../models/types.js';
+import { Collection, CollectionAccessObject } from '../models/types.js';
 
 const router: Router = express.Router({ mergeParams: true });
 
@@ -17,7 +17,8 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
     const guidelines: IGuidelines = await guidelineService.getGuidelines();
     const additionalLabel = guidelines.collections['text'].additionalLabel;
 
-    const collections: ICollection[] = await collectionService.getCollections(additionalLabel);
+    const collections: CollectionAccessObject[] =
+      await collectionService.getCollectionsWithText(additionalLabel);
 
     res.status(200).json(collections);
   } catch (error: unknown) {

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -48,8 +48,8 @@ router.get('/:uuid', async (req: Request, res: Response, next: NextFunction) => 
   const uuid: string = req.params.uuid;
 
   try {
-    // TODO: Part of the collection metadata workaround, fix later
-    const collection: Collection = await collectionService.getExtendedCollectionById(uuid);
+    const collection: CollectionAccessObject =
+      await collectionService.getExtendedCollectionById(uuid);
 
     res.status(200).json(collection);
   } catch (error: unknown) {

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2,11 +2,13 @@ import express, { Router } from 'express';
 import collectionRoutes from './collections.routes.js';
 import guideLinesRoutes from './guidelines.routes.js';
 import resourceRoutes from './resources.routes.js';
+import textRoutes from './text.routes.js';
 
 const router: Router = express.Router();
 
 router.use('/collections', collectionRoutes);
 router.use('/guidelines', guideLinesRoutes);
 router.use('/resources', resourceRoutes);
+router.use('/texts', textRoutes);
 
 export default router;

--- a/server/src/routes/text.routes.ts
+++ b/server/src/routes/text.routes.ts
@@ -1,0 +1,44 @@
+import express, { Request, Response, Router, NextFunction } from 'express';
+import characterRoutes from './characters.routes.js';
+import annotationRoutes from './annotations.routes.js';
+import TextService from '../services/text.service.js';
+import GuidelinesService from '../services/guidelines.service.js';
+import { IGuidelines } from '../models/IGuidelines.js';
+import IText from '../models/IText.js';
+import { TextAccessObject } from '../models/types.js';
+
+const router: Router = express.Router({ mergeParams: true });
+
+const textService: TextService = new TextService();
+const guidelineService: GuidelinesService = new GuidelinesService();
+
+// TODO: this is not really needed actually...remove
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const guidelines: IGuidelines = await guidelineService.getGuidelines();
+    const additionalLabel = guidelines.collections['text'].additionalLabel;
+
+    const collections: IText[] = await textService.getTexts();
+
+    res.status(200).json(collections);
+  } catch (error: unknown) {
+    next(error);
+  }
+});
+
+router.get('/:uuid', async (req: Request, res: Response, next: NextFunction) => {
+  const uuid: string = req.params.uuid;
+
+  try {
+    const text: TextAccessObject = await textService.getExtendedTextByUuid(uuid);
+
+    res.status(200).json(text);
+  } catch (error: unknown) {
+    next(error);
+  }
+});
+
+router.use('/:uuid/characters', characterRoutes);
+router.use('/:uuid/annotations', annotationRoutes);
+
+export default router;

--- a/server/src/routes/text.routes.ts
+++ b/server/src/routes/text.routes.ts
@@ -2,29 +2,11 @@ import express, { Request, Response, Router, NextFunction } from 'express';
 import characterRoutes from './characters.routes.js';
 import annotationRoutes from './annotations.routes.js';
 import TextService from '../services/text.service.js';
-import GuidelinesService from '../services/guidelines.service.js';
-import { IGuidelines } from '../models/IGuidelines.js';
-import IText from '../models/IText.js';
 import { TextAccessObject } from '../models/types.js';
 
 const router: Router = express.Router({ mergeParams: true });
 
 const textService: TextService = new TextService();
-const guidelineService: GuidelinesService = new GuidelinesService();
-
-// TODO: this is not really needed actually...remove
-router.get('/', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const guidelines: IGuidelines = await guidelineService.getGuidelines();
-    const additionalLabel = guidelines.collections['text'].additionalLabel;
-
-    const collections: IText[] = await textService.getTexts();
-
-    res.status(200).json(collections);
-  } catch (error: unknown) {
-    next(error);
-  }
-});
 
 router.get('/:uuid', async (req: Request, res: Response, next: NextFunction) => {
   const uuid: string = req.params.uuid;

--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -30,13 +30,13 @@ type CreatedAdditionalText = AdditionalText & {
 };
 
 export default class AnnotationService {
-  public async getAnnotations(collectionUuid: string): Promise<AnnotationData[]> {
+  public async getAnnotations(textUuid: string): Promise<AnnotationData[]> {
     const guidelineService: GuidelinesService = new GuidelinesService();
     const guidelines: IGuidelines = await guidelineService.getGuidelines();
 
     const query: string = `
     // Match all annotations for given selection
-    MATCH (c:Collection {uuid: $collectionUuid})<-[:PART_OF]-(t:Text)-[:HAS_ANNOTATION]->(a:Annotation)
+    MATCH (t:Text {uuid: $textUuid})-[:HAS_ANNOTATION]->(a:Annotation)
 
     // Fetch additional nodes by label defined in the guidelines
     WITH a, $guidelines.annotations.resources AS resources
@@ -84,10 +84,7 @@ export default class AnnotationService {
     }) AS annotations
     `;
 
-    const result: QueryResult = await Neo4jDriver.runQuery(query, {
-      collectionUuid,
-      guidelines,
-    });
+    const result: QueryResult = await Neo4jDriver.runQuery(query, { textUuid, guidelines });
 
     return result.records[0]?.get('annotations');
   }
@@ -177,7 +174,7 @@ export default class AnnotationService {
   }
 
   public async saveAnnotations(
-    collectionUuid: string,
+    textUuid: string,
     annotations: Annotation[],
   ): Promise<IAnnotation[]> {
     const processedAnnotations: ProcessedAnnotation[] =
@@ -208,7 +205,7 @@ export default class AnnotationService {
 
     WITH allAnnotations
 
-    MATCH (c:Collection {uuid: $collectionUuid})<-[:PART_OF]-(t:Text)
+    MATCH (t:Text {uuid: $textUuid})
 
     // 2. Handle other annotations (merge)
     UNWIND allAnnotations AS ann
@@ -307,7 +304,7 @@ export default class AnnotationService {
 
     // Set startIndex and andIndex properties of Annotation nodes
     
-    MATCH (c:Collection {uuid: $collectionUuid})<-[:PART_OF]-(t:Text)-[:NEXT_CHARACTER*]->(ch:Character)
+    MATCH (t:Text {uuid: $textUuid})-[:NEXT_CHARACTER*]->(ch:Character)
     WITH collect(ch) as characters, annotations
 
     UNWIND range(0, size(characters) - 1) AS idx
@@ -323,7 +320,7 @@ export default class AnnotationService {
     `;
 
     const result: QueryResult = await Neo4jDriver.runQuery(query, {
-      collectionUuid,
+      textUuid,
       annotations: processedAnnotations,
     });
 

--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -180,7 +180,7 @@ export default class AnnotationService {
     const processedAnnotations: ProcessedAnnotation[] =
       await this.processAnnotationsBeforeSaving(annotations);
 
-    console.dir(processedAnnotations, { depth: null });
+    // console.dir(processedAnnotations, { depth: null });
 
     // TODO: Improve query speed, way too many db hits
     const query: string = `

--- a/server/src/services/character.service.ts
+++ b/server/src/services/character.service.ts
@@ -5,14 +5,14 @@ import { Character } from '../models/types.js';
 
 export default class CharacterService {
   /**
-   * Retrieves chain of characters that belong to a collection's text node.
+   * Retrieves chain of characters that belong to a text node.
    *
-   * @param {string} collectionUuid - The UUID of the collection to retrieve characters for.
+   * @param {string} textUuid - The UUID of the text to retrieve characters for.
    * @return {Promise<Character[]>} A promise that resolves to an array of characters.
    */
-  public async getCharacters(collectionUuid: string): Promise<Character[]> {
+  public async getCharacters(textUuid: string): Promise<Character[]> {
     const query: string = `
-    MATCH (c:Collection {uuid: $collectionUuid})<-[:PART_OF]-(t:Text)-[:NEXT_CHARACTER*]->(char:Character)
+    MATCH (t:Text {uuid: $textUuid})-[:NEXT_CHARACTER*]->(char:Character)
     WITH char, [(char)-[:CHARACTER_HAS_ANNOTATION]->(a:Annotation) | 
       {
         uuid: a.uuid,
@@ -27,15 +27,15 @@ export default class CharacterService {
     }) AS characters
     `;
 
-    const result: QueryResult = await Neo4jDriver.runQuery(query, { collectionUuid });
+    const result: QueryResult = await Neo4jDriver.runQuery(query, { textUuid });
 
     return result.records[0]?.get('characters');
   }
 
   /**
-   * Updates the character chain that belongs to a collection's text node by splitting up the chain at the given start and end Character node.
+   * Updates the character chain that belongs to a text node by splitting up the chain at the given start and end Character node.
    *
-   * @param {string} collectionUuid - The UUID of the collection to update characters for.
+   * @param {string} textUuid - The UUID of the text to update characters for.
    * @param {string | null} uuidStart - The UUID of the starting character, or null if no starting character.
    * @param {string | null} uuidEnd - The UUID of the ending character, or null if no ending character.
    * @param {ICharacter[]} characters - The array of characters that will form the new chain snippet between given start and end Character node.
@@ -43,14 +43,14 @@ export default class CharacterService {
    * @return {Promise<ICharacter[]>} A promise that resolves to an array of the whole updated character chain.
    */
   public async saveCharacters(
-    collectionUuid: string,
+    textUuid: string,
     uuidStart: string | null,
     uuidEnd: string | null,
     characters: ICharacter[],
     text: string,
   ): Promise<ICharacter[]> {
     const query: string = `
-    MATCH (c:Collection {uuid: $collectionUuid})<-[:PART_OF]-(t:Text)
+    MATCH (t:Text {uuid: $textUuid})
     SET t.text = $text
     WITH t
     CALL atag.chains.update(t.uuid, $uuidStart, $uuidEnd, $characters, {
@@ -59,11 +59,11 @@ export default class CharacterService {
       relationshipType: "NEXT_CHARACTER"
     }) YIELD path
     UNWIND nodes(path) as n
-    RETURN COLLECT(n {.*}) as characters
+    RETURN collect(n {.*}) as characters
     `;
 
     const result: QueryResult = await Neo4jDriver.runQuery(query, {
-      collectionUuid,
+      textUuid,
       uuidStart,
       uuidEnd,
       characters,

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -49,12 +49,12 @@ export default class CollectionService {
 
     RETURN collect({
         collection: {
-            nodeLabel: [l in labels(c) WHERE l <> 'Collection' | l][0] ,
+            nodeLabels: [l IN labels(c) WHERE l <> 'Collection' | l],
             data: c {.*}
         }, 
         texts: [
             t IN texts | {
-                nodeLabel: [l IN labels(t) WHERE l <> 'Text' | l][0],
+                nodeLabels: [l IN labels(t) WHERE l <> 'Text' | l],
                 data: t {.*}
             }
         ]
@@ -111,12 +111,12 @@ export default class CollectionService {
 
     RETURN {
         collection: {
-            nodeLabel: [l in labels(c) WHERE l <> 'Collection' | l][0],
+            nodeLabels: [l IN labels(c) WHERE l <> 'Collection' | l],
             data: c {.*}
         }, 
         texts: [
             t IN texts | {
-                nodeLabel: [l IN labels(t) WHERE l <> 'Text' | l][0],
+                nodeLabels: [l IN labels(t) WHERE l <> 'Text' | l],
                 data: t {.*}
             }
         ]
@@ -276,7 +276,7 @@ export default class CollectionService {
       MATCH (c)<-[:PART_OF]-(t:Text {uuid: text.data.uuid})
       WITH t, text, [l IN labels(t) WHERE l <> 'Text'] AS labelsToRemove
       CALL apoc.create.removeLabels(t, labelsToRemove) YIELD node AS nodeBefore
-      CALL apoc.create.addLabels(t, [text.nodeLabel]) YIELD node AS nodeAfter
+      CALL apoc.create.addLabels(t, text.nodeLabels) YIELD node AS nodeAfter
 
       RETURN collect(t) as relabeledTexts
     }

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -4,7 +4,13 @@ import GuidelinesService from './guidelines.service.js';
 import NotFoundError from '../errors/not-found.error.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
-import { Collection, CollectionAccessObject } from '../models/types.js';
+import { CollectionAccessObject, CollectionPostData, Text } from '../models/types.js';
+
+type CollectionTextObject = {
+  all: Text[];
+  created: Text[];
+  deleted: Text[];
+};
 
 export default class CollectionService {
   /**
@@ -32,9 +38,14 @@ export default class CollectionService {
   public async getCollectionsWithTexts(additionalLabel: string): Promise<CollectionAccessObject[]> {
     const query: string = `
     MATCH (c:Collection:${additionalLabel})
-    OPTIONAL MATCH (c)<-[:PART_OF]-(t:Text)
 
-    WITH c, collect(t) AS texts
+    // Match optional Text node chain
+    OPTIONAL MATCH (c)<-[:PART_OF]-(tStart:Text)
+    WHERE NOT ()-[:NEXT]->(tStart)
+    OPTIONAL MATCH (tStart)-[:NEXT*]->(t:Text)
+
+    WITH c, tStart, collect(t) AS nextTexts
+    WITH c, coalesce(tStart, []) + nextTexts AS texts
 
     RETURN collect({
         collection: {
@@ -89,13 +100,18 @@ export default class CollectionService {
     // TODO: This query is not working with more than one additional node label. Considerate
     const query: string = `
     MATCH (c:Collection {uuid: $uuid})
-    OPTIONAL MATCH (c)<-[:PART_OF]-(t:Text)
 
-    WITH c, collect(t) AS texts
+    // Match optional Text node chain
+    OPTIONAL MATCH (c)<-[:PART_OF]-(tStart:Text)
+    WHERE NOT ()-[:NEXT]->(tStart)
+    OPTIONAL MATCH (tStart)-[:NEXT*]->(t:Text)
+
+    WITH c, tStart, collect(t) AS nextTexts
+    WITH c, coalesce(tStart, []) + nextTexts AS texts    
 
     RETURN {
         collection: {
-            nodeLabel: [l in labels(c) WHERE l <> 'Collection' | l][0] ,
+            nodeLabel: [l in labels(c) WHERE l <> 'Collection' | l][0],
             data: c {.*}
         }, 
         texts: [
@@ -150,6 +166,57 @@ export default class CollectionService {
     return result.records[0]?.get('collection');
   }
 
+  // TODO: Delete, since this will not be needed
+  // /**
+  //  * Updates the properties of a collection node with given UUID.
+  //  *
+  //  * @param {string} uuid - The UUID of the collection node to update.
+  //  * @param {Record<string, string>} data - The data for the collection node.
+  //  * @throws {NotFoundError} If the collection with the specified UUID is not found.
+  //  * @return {Promise<ICollection>} A promise that resolves to the updated collection node.
+  //  */
+  // public async updateCollection(uuid: string, data: Record<string, string>): Promise<ICollection> {
+  //   const query: string = `
+  //   MATCH (c:Collection {uuid: $uuid})
+  //   SET c = $data
+  //   RETURN c {.*} AS collection
+  //   `;
+
+  //   const result: QueryResult = await Neo4jDriver.runQuery(query, { uuid, data });
+  //   const updatedCollection: ICollection = result.records[0]?.get('collection');
+
+  //   if (!updatedCollection) {
+  //     throw new NotFoundError(`Collection with UUID ${uuid} not found`);
+  //   }
+
+  //   return updatedCollection;
+  // }
+
+  public processCollectionTextsBeforeSaving(data: CollectionPostData): CollectionTextObject {
+    const newData: CollectionAccessObject = data.data;
+    const initialData: CollectionAccessObject = data.initialData;
+
+    const initialTextUuids: string[] = initialData.texts.map(t => t.data.uuid);
+    const newTextUUids: string[] = newData.texts.map(t => t.data.uuid);
+
+    const createdTexts: Text[] = newData.texts.filter(
+      text => !initialTextUuids.includes(text.data.uuid),
+    );
+
+    const deletedTexts: Text[] = initialData.texts.filter(
+      text => !newTextUUids.includes(text.data.uuid),
+    );
+
+    const collectionTextObject: CollectionTextObject = {
+      all: newData.texts,
+      created: createdTexts,
+      deleted: deletedTexts,
+    };
+
+    return collectionTextObject;
+  }
+
+  // TODO: Rewrite JSDoc
   /**
    * Updates the properties of a collection node with given UUID.
    *
@@ -158,14 +225,62 @@ export default class CollectionService {
    * @throws {NotFoundError} If the collection with the specified UUID is not found.
    * @return {Promise<ICollection>} A promise that resolves to the updated collection node.
    */
-  public async updateCollection(uuid: string, data: Record<string, string>): Promise<ICollection> {
+  public async updateCollection(uuid: string, data: CollectionPostData): Promise<ICollection> {
+    const { collection } = data.data;
+    const texts: CollectionTextObject = this.processCollectionTextsBeforeSaving(data);
+
     const query: string = `
     MATCH (c:Collection {uuid: $uuid})
-    SET c = $data
+    
+    SET c = $collection.data
+
+    WITH c
+
+    // Delete Text nodes
+    CALL {
+      UNWIND $texts.deleted as textToDelete
+      MATCH (t:Text {uuid: textToDelete.data.uuid})
+      // TODO: Delete whole subgraph
+      DETACH DELETE t
+    }
+
+    // Create Text nodes
+    CALL {
+      WITH c
+
+      UNWIND $texts.created as textToCreate
+      MERGE (t:Text {uuid: textToCreate.data.uuid})-[:PART_OF]->(c)
+      WITH t, textToCreate
+      CALL apoc.create.addLabels(t, [textToCreate.nodeLabel]) YIELD node
+      SET t = textToCreate.data
+
+      RETURN collect(t) as createdTexts
+    }
+    
+    // Remove NEXT relationships from all texts
+    CALL {
+      WITH c
+      MATCH (c)<-[:PART_OF]->(t:Text)-[r:NEXT]->(t2:Text)
+      DETACH DELETE r
+    }
+
+    // Create new chain of NEXT relationships between nodes
+    CALL {
+        WITH c
+
+        UNWIND range(0, size($texts.all) - 2) AS idx
+        
+        MATCH (t1:Text {uuid: $texts.all[idx].data.uuid})
+        MATCH (t2:Text {uuid: $texts.all[idx + 1].data.uuid})
+        MERGE (t1)-[:NEXT]->(t2)
+        
+        RETURN collect(t1) as updatedTexts
+    }
+
     RETURN c {.*} AS collection
     `;
 
-    const result: QueryResult = await Neo4jDriver.runQuery(query, { uuid, data });
+    const result: QueryResult = await Neo4jDriver.runQuery(query, { uuid, collection, texts });
     const updatedCollection: ICollection = result.records[0]?.get('collection');
 
     if (!updatedCollection) {

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -166,32 +166,6 @@ export default class CollectionService {
     return result.records[0]?.get('collection');
   }
 
-  // TODO: Delete, since this will not be needed
-  // /**
-  //  * Updates the properties of a collection node with given UUID.
-  //  *
-  //  * @param {string} uuid - The UUID of the collection node to update.
-  //  * @param {Record<string, string>} data - The data for the collection node.
-  //  * @throws {NotFoundError} If the collection with the specified UUID is not found.
-  //  * @return {Promise<ICollection>} A promise that resolves to the updated collection node.
-  //  */
-  // public async updateCollection(uuid: string, data: Record<string, string>): Promise<ICollection> {
-  //   const query: string = `
-  //   MATCH (c:Collection {uuid: $uuid})
-  //   SET c = $data
-  //   RETURN c {.*} AS collection
-  //   `;
-
-  //   const result: QueryResult = await Neo4jDriver.runQuery(query, { uuid, data });
-  //   const updatedCollection: ICollection = result.records[0]?.get('collection');
-
-  //   if (!updatedCollection) {
-  //     throw new NotFoundError(`Collection with UUID ${uuid} not found`);
-  //   }
-
-  //   return updatedCollection;
-  // }
-
   public processCollectionTextsBeforeSaving(data: CollectionPostData): CollectionTextObject {
     const newData: CollectionAccessObject = data.data;
     const initialData: CollectionAccessObject = data.initialData;
@@ -216,12 +190,12 @@ export default class CollectionService {
     return collectionTextObject;
   }
 
-  // TODO: Rewrite JSDoc
   /**
-   * Updates the properties of a collection node with given UUID.
+   * Updates the properties of a Collection node with given UUID as well as its Text node network
+   * (creating new nodes, deleting old nodes, changing order of existing nodes).
    *
    * @param {string} uuid - The UUID of the collection node to update.
-   * @param {Record<string, string>} data - The data for the collection node.
+   * @param {CollectionPostData} data - The data containing updates for the collection.
    * @throws {NotFoundError} If the collection with the specified UUID is not found.
    * @return {Promise<ICollection>} A promise that resolves to the updated collection node.
    */

--- a/server/src/services/text.service.ts
+++ b/server/src/services/text.service.ts
@@ -52,7 +52,7 @@ export default class TextService {
             nodeLabel: [l in labels(c) WHERE l <> 'Collection' | l][0],
             data: c {.*}
         },
-        path: p
+        path: [n IN reverse(nodes(p)) | {nodeLabels: labels(n), data: n {.*}}]
     } as text
     `;
 

--- a/server/src/services/text.service.ts
+++ b/server/src/services/text.service.ts
@@ -1,0 +1,68 @@
+import { QueryResult } from 'neo4j-driver';
+import Neo4jDriver from '../database/neo4j.js';
+import GuidelinesService from './guidelines.service.js';
+import NotFoundError from '../errors/not-found.error.js';
+import ICollection from '../models/ICollection.js';
+import { IGuidelines } from '../models/IGuidelines.js';
+import { Collection } from '../models/types.js';
+import IText from '../models/IText.js';
+import { TextAccessObject } from '../models/types.js';
+
+export default class TextService {
+  /**
+   * Retrieves text nodes based on the additional label provided.
+   *
+   * @param {string} additionalLabel - The additional label to match in the query, for example "MainText" for text nodes that are
+   * the entry point for a letter text.
+   * @return {Promise<IText[]>} A promise that resolves to an array of texts.
+   */
+  public async getTexts(additionalLabel?: string): Promise<IText[]> {
+    const query: string = `
+    MATCH (t:Text${additionalLabel ? `:${additionalLabel}` : ''})
+    RETURN COLLECT(t {.*}) as texts
+    `;
+
+    const result: QueryResult = await Neo4jDriver.runQuery(query);
+
+    return result.records[0]?.get('texts');
+  }
+
+  /**
+   * Retrieves extended data of a specified text node (Text node, corresponding Collection node and path to top-level Collection node).
+   *
+   * @param {string} uuid - The UUID of the text node to retrieve.
+   * @throws {NotFoundError} If the text with the specified UUID is not found.
+   * @return {Promise<TextAccessObject>} A promise that resolves to the retrieved extended text.
+   */
+  public async getExtendedTextByUuid(uuid: string): Promise<TextAccessObject> {
+    // TODO: This query is not working with more than one additional node label. Considerate
+    // TODO: "Letter" label should be made dynamic
+    const query: string = `
+    MATCH (t:Text {uuid: $uuid})
+    WITH t
+    MATCH (t)-[:PART_OF]->(c:Collection)
+    MATCH p = (t)-[:HAS_TEXT | REFERS_TO | HAS_ANNOTATION | PART_OF*]-(:Collection:Letter)
+
+    RETURN {
+        text: {
+            nodeLabel: [l in labels(t) WHERE l <> 'Text' | l][0],
+            data: t {.*}
+        },
+        collection: {
+            nodeLabel: [l in labels(c) WHERE l <> 'Collection' | l][0],
+            data: c {.*}
+        },
+        path: p
+    } as text
+    `;
+
+    const result: QueryResult = await Neo4jDriver.runQuery(query, { uuid });
+    const text: TextAccessObject = result.records[0]?.get('text');
+
+    if (!text) {
+      throw new NotFoundError(`Text with UUID ${uuid} not found`);
+    }
+
+    return text;
+  }
+}

--- a/server/src/services/text.service.ts
+++ b/server/src/services/text.service.ts
@@ -45,11 +45,11 @@ export default class TextService {
 
     RETURN {
         text: {
-            nodeLabel: [l in labels(t) WHERE l <> 'Text' | l][0],
+            nodeLabels: [l IN labels(t) WHERE l <> 'Text' | l],
             data: t {.*}
         },
         collection: {
-            nodeLabel: [l in labels(c) WHERE l <> 'Collection' | l][0],
+            nodeLabels: [l IN labels(c) WHERE l <> 'Collection' | l],
             data: c {.*}
         },
         path: [n IN reverse(nodes(p)) | {nodeLabels: labels(n), data: n {.*}}]

--- a/server/src/services/text.service.ts
+++ b/server/src/services/text.service.ts
@@ -1,10 +1,6 @@
 import { QueryResult } from 'neo4j-driver';
 import Neo4jDriver from '../database/neo4j.js';
-import GuidelinesService from './guidelines.service.js';
 import NotFoundError from '../errors/not-found.error.js';
-import ICollection from '../models/ICollection.js';
-import { IGuidelines } from '../models/IGuidelines.js';
-import { Collection } from '../models/types.js';
 import IText from '../models/IText.js';
 import { TextAccessObject } from '../models/types.js';
 
@@ -12,7 +8,7 @@ export default class TextService {
   /**
    * Retrieves text nodes based on the additional label provided.
    *
-   * @param {string} additionalLabel - The additional label to match in the query, for example "MainText" for text nodes that are
+   * @param {string} additionalLabel - The additional label to match in the query, for example "LetterText" for text nodes that are
    * the entry point for a letter text.
    * @return {Promise<IText[]>} A promise that resolves to an array of texts.
    */
@@ -35,7 +31,6 @@ export default class TextService {
    * @return {Promise<TextAccessObject>} A promise that resolves to the retrieved extended text.
    */
   public async getExtendedTextByUuid(uuid: string): Promise<TextAccessObject> {
-    // TODO: This query is not working with more than one additional node label. Considerate
     // TODO: "Letter" label should be made dynamic
     const query: string = `
     MATCH (t:Text {uuid: $uuid})


### PR DESCRIPTION
Restructuring of the Editor to allow users to add multiple Texts to the same Collection. This mirrors the data model where multiple `Text` nodes can be connected via `PART_OF` relationship to the same `Collection` node and are connected to the next `Text` node via `NEXT` relationship. 

Key changes:
- Separation between Collection and Text handling in frontend: Overview page shows the Collections, and each Collection has its own page now where its node properties and connected Texts can be handled.
- Separation between Collection and Text handling in backend: Collections and Texts get their own routes/services.
- Multiple Texts can be added/deleted to a Collection, and the order of the Texts can be changed.
- Editor page shows Collection data as read-only, together with more information about the role of the Text in the network (Path, Text node labels etc.).
- Restructuring of guidelines to determine possible labels to set on a Text node
