### PR TITLE
Make Collection node labels dynamic

### DIFF
--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -77,7 +77,8 @@ const {
 } = useAnnotationStore();
 const { removeAnnotationFromCharacters } = useCharactersStore();
 const { newRangeAnchorUuid } = useEditorStore();
-const { guidelines, getAnnotationConfig, getAnnotationFields } = useGuidelinesStore();
+const { guidelines, getAnnotationConfig, getAnnotationFields, getCollectionFields } =
+  useGuidelinesStore();
 
 const config: AnnotationType = getAnnotationConfig(annotation.data.properties.type);
 const fields: AnnotationProperty[] = getAnnotationFields(annotation.data.properties.type);
@@ -350,10 +351,10 @@ function toggleAdditionalTextPreviewMode(uuid: string): void {
 
 function addAdditionalText(): void {
   // TODO: This should be dynamic since the key is not always 'comment'
-  const fields = guidelines.value.collections['comment'].properties;
+  const defaultFields: CollectionProperty[] = getCollectionFields('comment');
   const newCollectionProperties: ICollection = {} as ICollection;
 
-  fields.forEach((field: CollectionProperty) => {
+  defaultFields.forEach((field: CollectionProperty) => {
     // TODO: Is this needed? Or should Collection Properties always be text?
     switch (field.type) {
       case 'text':

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -77,7 +77,7 @@ const {
 } = useAnnotationStore();
 const { removeAnnotationFromCharacters } = useCharactersStore();
 const { newRangeAnchorUuid } = useEditorStore();
-const { guidelines, getAnnotationConfig, getAnnotationFields, getCollectionFields } =
+const { guidelines, getAnnotationConfig, getAnnotationFields, getCollectionConfigFields } =
   useGuidelinesStore();
 
 const config: AnnotationType = getAnnotationConfig(annotation.data.properties.type);
@@ -351,7 +351,7 @@ function toggleAdditionalTextPreviewMode(uuid: string): void {
 
 function addAdditionalText(): void {
   // TODO: This should be dynamic since the key is not always 'comment'
-  const defaultFields: CollectionProperty[] = getCollectionFields('comment');
+  const defaultFields: CollectionProperty[] = getCollectionConfigFields('Comment');
   const newCollectionProperties: ICollection = {} as ICollection;
 
   defaultFields.forEach((field: CollectionProperty) => {

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -351,7 +351,7 @@ function toggleAdditionalTextPreviewMode(uuid: string): void {
 
 function addAdditionalText(): void {
   // TODO: This should be dynamic since the key is not always 'comment'
-  const defaultFields: CollectionProperty[] = getCollectionConfigFields('Comment');
+  const defaultFields: CollectionProperty[] = getCollectionConfigFields(['Comment']);
   const newCollectionProperties: ICollection = {} as ICollection;
 
   defaultFields.forEach((field: CollectionProperty) => {

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -23,12 +23,9 @@ const { getCollectionConfigFields } = useGuidelinesStore();
 const tableData: CollectionTableEntry[] = getCollectionTableData();
 
 function getCollectionTableData() {
-  // TODO: Still a workaround, should be mady dynamic.
-  const fields: CollectionProperty[] = correspondingCollection.value.nodeLabels.includes('Letter')
-    ? getCollectionConfigFields(['Letter'])
-    : getCollectionConfigFields(['Comment']);
-
-  console.log(fields);
+  const fields: CollectionProperty[] = getCollectionConfigFields(
+    correspondingCollection.value.nodeLabels,
+  );
 
   return fields.map(field => ({
     property: field.name,

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -25,8 +25,8 @@ const tableData: CollectionTableEntry[] = getCollectionTableData();
 function getCollectionTableData() {
   // TODO: Still a workaround, should be mady dynamic.
   const fields: CollectionProperty[] = correspondingCollection.value.nodeLabels.includes('Letter')
-    ? getCollectionConfigFields('Letter')
-    : getCollectionConfigFields('Comment');
+    ? getCollectionConfigFields(['Letter'])
+    : getCollectionConfigFields(['Comment']);
 
   console.log(fields);
 

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -18,15 +18,17 @@ type CollectionTableEntry = {
 };
 
 const { text, correspondingCollection, path } = useTextStore();
-const { getCollectionFields } = useGuidelinesStore();
+const { getCollectionConfigFields } = useGuidelinesStore();
 
 const tableData: CollectionTableEntry[] = getCollectionTableData();
 
 function getCollectionTableData() {
   // TODO: Still a workaround, should be mady dynamic.
   const fields: CollectionProperty[] = correspondingCollection.value.nodeLabels.includes('Letter')
-    ? getCollectionFields('text')
-    : getCollectionFields('comment');
+    ? getCollectionConfigFields('Letter')
+    : getCollectionConfigFields('Comment');
+
+  console.log(fields);
 
   return fields.map(field => ({
     property: field.name,

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -35,7 +35,11 @@ onMounted(async (): Promise<void> => {
   await getGuidelines();
 
   // TODO: This approach is bad since possible data keys are reserved...
-  columns.value = ['nodeLabels', ...getCollectionConfigFields('Letter').map(f => f.name), 'texts'];
+  columns.value = [
+    'nodeLabels',
+    ...getCollectionConfigFields(['Letter']).map(f => f.name),
+    'texts',
+  ];
 });
 
 function getColumnWidth(columnName: string): string {

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -34,10 +34,16 @@ const tableData: ComputedRef<CollectionTableEntry[]> = computed(() => {
 onMounted(async (): Promise<void> => {
   await getGuidelines();
 
+  // Get Collection type that is shown in the table and does not only exist as anchor to additional text
+  // Needs to be overhauled anyway when whole hierarchies should be handled in the future
+  const primaryCollectionLabel = guidelines.value.collections.types.find(
+    t => t.level === 'primary',
+  )?.additionalLabel;
+
   // TODO: This approach is bad since possible data keys are reserved...
   columns.value = [
     'nodeLabels',
-    ...getCollectionConfigFields(['Letter']).map(f => f.name),
+    ...getCollectionConfigFields([primaryCollectionLabel]).map(f => f.name),
     'texts',
   ];
 });

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -18,7 +18,7 @@ const props = defineProps<{
   collections: CollectionAccessObject[] | null;
 }>();
 
-const { guidelines, getCollectionFields } = useGuidelinesStore();
+const { guidelines, getCollectionConfigFields } = useGuidelinesStore();
 const columns = ref<string[]>([]);
 
 const tableData: ComputedRef<CollectionTableEntry[]> = computed(() => {
@@ -35,7 +35,7 @@ onMounted(async (): Promise<void> => {
   await getGuidelines();
 
   // TODO: This approach is bad since possible data keys are reserved...
-  columns.value = ['nodeLabels', ...getCollectionFields('text').map(f => f.name), 'texts'];
+  columns.value = ['nodeLabels', ...getCollectionConfigFields('Letter').map(f => f.name), 'texts'];
 });
 
 function getColumnWidth(columnName: string): string {

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -6,6 +6,7 @@ import LoadingSpinner from './LoadingSpinner.vue';
 import { buildFetchUrl, capitalize } from '../utils/helper/helper';
 import Column from 'primevue/column';
 import DataTable from 'primevue/datatable';
+import { Tag } from 'primevue';
 import { IGuidelines } from '../models/IGuidelines';
 import { CollectionAccessObject, CollectionProperty } from '../models/types';
 
@@ -25,6 +26,7 @@ const tableData: ComputedRef<CollectionTableEntry[]> = computed(() => {
     return {
       ...collection.collection.data,
       texts: collection.texts.length,
+      nodeLabels: collection.collection.nodeLabels,
     };
   });
 });
@@ -32,8 +34,20 @@ const tableData: ComputedRef<CollectionTableEntry[]> = computed(() => {
 onMounted(async (): Promise<void> => {
   await getGuidelines();
 
-  columns.value = [...getCollectionFields('text').map(f => f.name), 'texts'];
+  // TODO: This approach is bad since possible data keys are reserved...
+  columns.value = ['nodeLabels', ...getCollectionFields('text').map(f => f.name), 'texts'];
 });
+
+function getColumnWidth(columnName: string): string {
+  switch (columnName) {
+    case 'nodeLabels':
+      return '8rem';
+    case 'texts':
+      return '5rem';
+    default:
+      return 'auto';
+  }
+}
 
 // TODO: getGuidelines exists in multiple components now, should be moved to a shared location
 async function getGuidelines(): Promise<void> {
@@ -58,7 +72,6 @@ async function getGuidelines(): Promise<void> {
 <template>
   <div class="flex-grow-1 overflow-y-auto">
     <LoadingSpinner v-if="!tableData" />
-    <!-- TODO: Fix sorting... -->
     <DataTable
       v-else
       scrollable
@@ -81,7 +94,7 @@ async function getGuidelines(): Promise<void> {
         :field="col"
         :header="capitalize(col)"
         sortable
-        :headerStyle="col === 'texts' ? `width: 5rem` : ''"
+        :headerStyle="`width: ${getColumnWidth(col)}`"
       >
         <template #body="{ data }">
           <!-- TODO: This should come from the configuration... -->
@@ -93,13 +106,20 @@ async function getGuidelines(): Promise<void> {
             v-tooltip.hover.top="{ value: data[col], showDelay: 0 }"
             >{{ data[col] }}</RouterLink
           >
-          <span
-            v-else-if="col !== 'texts'"
-            class="cell-info"
-            v-tooltip.hover.top="{ value: data[col], showDelay: 0 }"
-            >{{ data[col] }}</span
-          >
-          <span v-else class="cell-info">{{ data[col] }}</span>
+          <span v-else-if="col === 'texts'" class="cell-info">{{ data[col] }}</span>
+          <span v-else-if="col === 'nodeLabels'" class="cell-info">
+            <div class="box flex" style="flex-wrap: wrap">
+              <Tag
+                v-for="label in data.nodeLabels"
+                :value="label"
+                severity="contrast"
+                class="mr-1 mb-1 mt-1 inline-block"
+              />
+            </div>
+          </span>
+          <span v-else class="cell-info" v-tooltip.hover.top="{ value: data[col], showDelay: 0 }">{{
+            data[col]
+          }}</span>
         </template>
       </Column>
     </DataTable>

--- a/client/src/components/OverviewToolbar.vue
+++ b/client/src/components/OverviewToolbar.vue
@@ -17,7 +17,7 @@ import { Collection } from '../models/types';
 
 const emit = defineEmits(['collectionCreated', 'searchInputChanged']);
 
-const { getAvailableCollectionLabels, getCollectionFields } = useGuidelinesStore();
+const { getAvailableCollectionLabels, getCollectionConfigFields } = useGuidelinesStore();
 
 const searchInput = ref<string>('');
 const newCollectionData = ref<Collection>(null);
@@ -39,7 +39,7 @@ const inputIsValid: ComputedRef<boolean> = computed((): boolean => {
   const selectedLabelsValid: boolean =
     availableCollectionLabels.value.length === 0 || newCollectionData.value.nodeLabels.length > 0;
 
-  const requiredFieldsValid: boolean = getCollectionFields('text')
+  const requiredFieldsValid: boolean = getCollectionConfigFields('Letter')
     .filter(field => field.required)
     .every(field => newCollectionData.value?.data[field.name]?.toString().trim() !== '');
 
@@ -112,7 +112,9 @@ async function getGuidelines(): Promise<void> {
     // TODO: Load guidelines only once? Should be enough...
     // Initialize newCollectionData with empty strings to include them in form data
     newCollectionData.value = {
-      data: Object.fromEntries(getCollectionFields('text').map(f => [f.name, ''])) as ICollection,
+      data: Object.fromEntries(
+        getCollectionConfigFields('Letter').map(f => [f.name, '']),
+      ) as ICollection,
       nodeLabels: [],
     };
 
@@ -187,7 +189,7 @@ function handleSearchInput(): void {
           <h4 class="text-center">Add data</h4>
           <div
             class="input-container flex align-items-center gap-3 mb-3"
-            v-for="(property, index) in getCollectionFields('text')"
+            v-for="(property, index) in getCollectionConfigFields('Letter')"
           >
             <label :for="property.name" class="font-semibold w-6rem"
               >{{ capitalize(property.name) }}

--- a/client/src/components/OverviewToolbar.vue
+++ b/client/src/components/OverviewToolbar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue';
+import { useGuidelinesStore } from '../store/guidelines';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
 import IconField from 'primevue/iconfield';
@@ -20,6 +21,8 @@ const guidelines = ref<IGuidelines>({} as IGuidelines);
 const dialogIsVisible = ref<boolean>(false);
 const guidelinesAreLoaded = ref<boolean>(false);
 const asyncOperationRunning = ref<boolean>(false);
+
+const { getCollectionFields } = useGuidelinesStore();
 
 // TODO: Add information about creation status for message in Overview.vue (success/fail, new label etc.)
 // TODO: Add error message to dialog if collection could not be created
@@ -84,7 +87,7 @@ async function getGuidelines(): Promise<void> {
 
     // TODO: Load guidelines only once? Should be enough...
     // Initialize newCollectionData with empty strings to include them in form data
-    guidelines.value.collections['text'].properties.forEach(property => {
+    getCollectionFields('text').forEach(property => {
       newCollectionData.value[property.name] = '';
     });
 
@@ -139,7 +142,7 @@ function handleSearchInput(): void {
       <div
         v-if="guidelinesAreLoaded"
         class="input-container"
-        v-for="(property, index) in guidelines.collections['text'].properties"
+        v-for="(property, index) in getCollectionFields('text')"
         v-show="property.required === true"
       >
         <div class="flex align-items-center gap-3 mb-3">

--- a/client/src/components/OverviewToolbar.vue
+++ b/client/src/components/OverviewToolbar.vue
@@ -39,7 +39,7 @@ const inputIsValid: ComputedRef<boolean> = computed((): boolean => {
   const selectedLabelsValid: boolean =
     availableCollectionLabels.value.length === 0 || newCollectionData.value.nodeLabels.length > 0;
 
-  const requiredFieldsValid: boolean = getCollectionConfigFields('Letter')
+  const requiredFieldsValid: boolean = getCollectionConfigFields(['Letter'])
     .filter(field => field.required)
     .every(field => newCollectionData.value?.data[field.name]?.toString().trim() !== '');
 
@@ -113,7 +113,7 @@ async function getGuidelines(): Promise<void> {
     // Initialize newCollectionData with empty strings to include them in form data
     newCollectionData.value = {
       data: Object.fromEntries(
-        getCollectionConfigFields('Letter').map(f => [f.name, '']),
+        getCollectionConfigFields(['Letter']).map(f => [f.name, '']),
       ) as ICollection,
       nodeLabels: [],
     };
@@ -189,7 +189,7 @@ function handleSearchInput(): void {
           <h4 class="text-center">Add data</h4>
           <div
             class="input-container flex align-items-center gap-3 mb-3"
-            v-for="(property, index) in getCollectionConfigFields('Letter')"
+            v-for="(property, index) in getCollectionConfigFields(['Letter'])"
           >
             <label :for="property.name" class="font-semibold w-6rem"
               >{{ capitalize(property.name) }}

--- a/client/src/components/OverviewToolbar.vue
+++ b/client/src/components/OverviewToolbar.vue
@@ -1,33 +1,57 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ComputedRef, ref } from 'vue';
 import { useGuidelinesStore } from '../store/guidelines';
 import Button from 'primevue/button';
 import Dialog from 'primevue/dialog';
 import IconField from 'primevue/iconfield';
 import InputIcon from 'primevue/inputicon';
 import InputText from 'primevue/inputtext';
+import { MultiSelect } from 'primevue';
 import Skeleton from 'primevue/skeleton';
+import Tag from 'primevue/tag';
 import Toolbar from 'primevue/toolbar';
 import { buildFetchUrl, capitalize, cloneDeep } from '../utils/helper/helper';
 import ICollection from '../models/ICollection';
 import { IGuidelines } from '../models/IGuidelines';
+import { Collection } from '../models/types';
 
 const emit = defineEmits(['collectionCreated', 'searchInputChanged']);
 
+const { getAvailableCollectionLabels, getCollectionFields } = useGuidelinesStore();
+
 const searchInput = ref<string>('');
-const newCollectionData = ref<Record<string, string>>({});
+const newCollectionData = ref<Collection>(null);
 const guidelines = ref<IGuidelines>({} as IGuidelines);
 
 const dialogIsVisible = ref<boolean>(false);
 const guidelinesAreLoaded = ref<boolean>(false);
 const asyncOperationRunning = ref<boolean>(false);
 
-const { getCollectionFields } = useGuidelinesStore();
+const availableCollectionLabels = computed(getAvailableCollectionLabels);
+
+// TODO: replace this with general form handling in the future
+// Used for enabling/disabling buttons when form inputs don't satisfy requirements
+const inputIsValid: ComputedRef<boolean> = computed((): boolean => {
+  if (dialogIsVisible.value && !guidelinesAreLoaded.value) {
+    return false;
+  }
+
+  const selectedLabelsValid: boolean =
+    availableCollectionLabels.value.length === 0 || newCollectionData.value.nodeLabels.length > 0;
+
+  const requiredFieldsValid: boolean = getCollectionFields('text')
+    .filter(field => field.required)
+    .every(field => newCollectionData.value?.data[field.name]?.toString().trim() !== '');
+
+  return selectedLabelsValid && requiredFieldsValid;
+});
 
 // TODO: Add information about creation status for message in Overview.vue (success/fail, new label etc.)
 // TODO: Add error message to dialog if collection could not be created
 async function createNewCollection(): Promise<void> {
   console.log(cloneDeep(newCollectionData.value));
+
+  return;
 
   asyncOperationRunning.value = true;
 
@@ -51,7 +75,7 @@ async function createNewCollection(): Promise<void> {
 
     const createdCollection: ICollection = await response.json();
 
-    newCollectionData.value = {};
+    newCollectionData.value = {} as Collection;
     dialogIsVisible.value = false;
 
     emit('collectionCreated', createdCollection);
@@ -68,7 +92,7 @@ async function showDialog(): Promise<void> {
 }
 
 async function hideDialog(): Promise<void> {
-  newCollectionData.value = {};
+  newCollectionData.value = null;
   dialogIsVisible.value = false;
   guidelinesAreLoaded.value = false;
 }
@@ -87,9 +111,10 @@ async function getGuidelines(): Promise<void> {
 
     // TODO: Load guidelines only once? Should be enough...
     // Initialize newCollectionData with empty strings to include them in form data
-    getCollectionFields('text').forEach(property => {
-      newCollectionData.value[property.name] = '';
-    });
+    newCollectionData.value = {
+      data: Object.fromEntries(getCollectionFields('text').map(f => [f.name, ''])) as ICollection,
+      nodeLabels: [],
+    };
 
     guidelinesAreLoaded.value = true;
   } catch (error: unknown) {
@@ -139,27 +164,47 @@ function handleSearchInput(): void {
       <h2 class="w-full text-center m-0">Add new Collection</h2>
     </template>
     <form @submit.prevent="createNewCollection">
-      <div
-        v-if="guidelinesAreLoaded"
-        class="input-container"
-        v-for="(property, index) in getCollectionFields('text')"
-        v-show="property.required === true"
-      >
-        <div class="flex align-items-center gap-3 mb-3">
-          <label :for="property.name" class="font-semibold w-6rem"
-            >{{ capitalize(property.name) }}
-          </label>
-          <InputText
-            :id="property.name"
-            :required="property.required"
-            :autofocus="index === 0"
-            :key="property.name"
-            v-model="newCollectionData[property.name]"
-            class="flex-auto"
-            spellcheck="false"
-          />
+      <div v-if="guidelinesAreLoaded">
+        <div class="select-label-container flex flex-column align-items-center">
+          <h4 class="mt-0">Select labels</h4>
+          <MultiSelect
+            v-model="newCollectionData.nodeLabels"
+            :options="availableCollectionLabels"
+            display="chip"
+            :invalid="
+              availableCollectionLabels?.length > 0 && newCollectionData?.nodeLabels?.length === 0
+            "
+            placeholder="Select labels"
+            class="text-center"
+            :filter="false"
+          >
+            <template #chip="{ value }">
+              <Tag :value="value" severity="contrast" class="mr-1" />
+            </template>
+          </MultiSelect>
+        </div>
+        <div class="select-data-container">
+          <h4 class="text-center">Add data</h4>
+          <div
+            class="input-container flex align-items-center gap-3 mb-3"
+            v-for="(property, index) in getCollectionFields('text')"
+          >
+            <label :for="property.name" class="font-semibold w-6rem"
+              >{{ capitalize(property.name) }}
+            </label>
+            <InputText
+              :id="property.name"
+              :required="property.required"
+              :autofocus="index === 0"
+              :key="property.name"
+              v-model="newCollectionData.data[property.name] as string"
+              class="flex-auto"
+              spellcheck="false"
+            />
+          </div>
         </div>
       </div>
+
       <div v-else class="skeleton-container">
         <div v-for="_n in 4" class="flex flex-row gap-2">
           <Skeleton class="mb-3" height="2rem" width="10rem"></Skeleton>
@@ -180,6 +225,7 @@ function handleSearchInput(): void {
           label="Create"
           title="Create new text"
           :loading="asyncOperationRunning"
+          :disabled="!inputIsValid"
         ></Button>
       </div>
     </form>

--- a/client/src/models/IGuidelines.ts
+++ b/client/src/models/IGuidelines.ts
@@ -7,10 +7,15 @@ import {
 
 export interface IGuidelines {
   collections: {
-    type: string;
-    additionalLabel: string /* "Letter" etc. */;
-    properties: CollectionProperty[];
-  }[];
+    properties: {
+      system: CollectionProperty[];
+      base: CollectionProperty[];
+    };
+    types: {
+      additionalLabel: string;
+      properties: CollectionProperty[];
+    }[];
+  };
   annotations: {
     additionalTexts: string[];
     types: AnnotationType[];

--- a/client/src/models/IGuidelines.ts
+++ b/client/src/models/IGuidelines.ts
@@ -13,6 +13,9 @@ export interface IGuidelines {
     };
     types: {
       additionalLabel: string;
+      level:
+        | 'primary'
+        | 'secondary' /* Quick fix to determine which collections should be loaded into the overview table */;
       properties: CollectionProperty[];
     }[];
   };

--- a/client/src/models/IGuidelines.ts
+++ b/client/src/models/IGuidelines.ts
@@ -7,11 +7,10 @@ import {
 
 export interface IGuidelines {
   collections: {
-    [index: string] /* letter, document etc. */ : {
-      additionalLabel: string /* "Letter" etc. */;
-      properties: CollectionProperty[];
-    };
-  };
+    type: string;
+    additionalLabel: string /* "Letter" etc. */;
+    properties: CollectionProperty[];
+  }[];
   annotations: {
     additionalTexts: string[];
     types: AnnotationType[];

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -94,6 +94,20 @@ export function useGuidelinesStore() {
   }
 
   /**
+   * Retrieves all available field configurations for collection properties.
+   *
+   * This method gathers all available collection labels and fetches their corresponding
+   * field configurations, which are used for rendering data tables or input fields in forms.
+   *
+   * @return {CollectionProperty[]} The field configurations for all available collection types.
+   */
+  function getAllCollectionConfigFields(): CollectionProperty[] {
+    const availableCollectionLabels: string[] = getAvailableCollectionLabels();
+
+    return getCollectionConfigFields(availableCollectionLabels);
+  }
+
+  /**
    * Groups the annotation types by category.
    *
    * @return {Record<string, AnnotationType[]>} An object where the keys are the categories and the values are arrays of annotation types belonging to that category.
@@ -118,6 +132,7 @@ export function useGuidelinesStore() {
   return {
     groupedAnnotationTypes,
     guidelines,
+    getAllCollectionConfigFields,
     getAnnotationConfig,
     getAnnotationFields,
     getAvailableCollectionLabels,

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -71,14 +71,16 @@ export function useGuidelinesStore() {
   }
 
   /**
-   * Retrieves field configuration of a collection of given type. Contains information about rendering behaviour as well as validation rules.
+   * Retrieves field configuration of a collection with given additional node label. Contains information about rendering behaviour as well as validation rules.
    * Used for rendering data tables or input fields in forms.
    *
-   * @param {string} type - The type of the collection.
+   * @param {string} nodeLabel - The additional label of the collection.
    * @return {CollectionProperty[]} The field configurations for the collection type.
    */
-  function getCollectionFields(type: string): CollectionProperty[] {
-    return guidelines.value?.collections.find(c => c.type === type)?.properties ?? [];
+  function getCollectionConfigFields(nodeLabel: string): CollectionProperty[] {
+    return (
+      guidelines.value?.collections.find(c => c.additionalLabel === nodeLabel)?.properties ?? []
+    );
   }
 
   /**
@@ -110,7 +112,7 @@ export function useGuidelinesStore() {
     getAnnotationFields,
     getAvailableCollectionLabels,
     getAvailableTextLabels,
-    getCollectionFields,
+    getCollectionConfigFields,
     initializeGuidelines,
   };
 }

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -58,7 +58,7 @@ export function useGuidelinesStore() {
    * @return {string[]} The available labels.
    */
   function getAvailableCollectionLabels(): string[] {
-    return guidelines.value?.collections.map(collection => collection.additionalLabel) ?? [];
+    return guidelines.value?.collections.types.map(collection => collection.additionalLabel) ?? [];
   }
 
   /**
@@ -71,16 +71,26 @@ export function useGuidelinesStore() {
   }
 
   /**
-   * Retrieves field configuration of a collection with given additional node label. Contains information about rendering behaviour as well as validation rules.
+   * Retrieves field configuration of a collection with given additional node labels. Contains information about rendering behaviour as well as validation rules.
    * Used for rendering data tables or input fields in forms.
    *
-   * @param {string} nodeLabel - The additional label of the collection.
+   * @param {string[]} nodeLabels - The additional labels of the collection.
    * @return {CollectionProperty[]} The field configurations for the collection type.
    */
-  function getCollectionConfigFields(nodeLabel: string): CollectionProperty[] {
-    return (
-      guidelines.value?.collections.find(c => c.additionalLabel === nodeLabel)?.properties ?? []
+  function getCollectionConfigFields(nodeLabels: string[]): CollectionProperty[] {
+    const system: CollectionProperty[] = guidelines?.value.collections.properties.system;
+    const base: CollectionProperty[] = guidelines?.value.collections.properties.base;
+    const additional: CollectionProperty[] = guidelines?.value.collections.types.reduce(
+      (total: CollectionProperty[], curr) => {
+        if (nodeLabels.includes(curr.additionalLabel)) {
+          total.push(...curr.properties);
+        }
+        return total;
+      },
+      [],
     );
+
+    return [...system, ...base, ...additional];
   }
 
   /**

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -70,7 +70,7 @@ export function useGuidelinesStore() {
    * @return {CollectionProperty[]} The field configurations for the collection type.
    */
   function getCollectionFields(type: string): CollectionProperty[] {
-    return guidelines.value.collections[type].properties;
+    return guidelines.value?.collections.find(c => c.type === type)?.properties ?? [];
   }
 
   /**

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -53,12 +53,20 @@ export function useGuidelinesStore() {
   }
 
   /**
+   * Retrieves the available labels that can be assigned to a Collection node.
+   *
+   * @return {string[]} The available labels.
+   */
+  function getAvailableCollectionLabels(): string[] {
+    return guidelines.value?.collections.map(collection => collection.additionalLabel) ?? [];
+  }
+
+  /**
    * Retrieves the available labels that can be assigned to a no Text node.
    *
    * @return {string[]} The available labels.
    */
   function getAvailableTextLabels(): string[] {
-    console.log(guidelines.value);
     return guidelines.value.texts.additionalLabels;
   }
 
@@ -100,6 +108,7 @@ export function useGuidelinesStore() {
     guidelines,
     getAnnotationConfig,
     getAnnotationFields,
+    getAvailableCollectionLabels,
     getAvailableTextLabels,
     getCollectionFields,
     initializeGuidelines,

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -51,7 +51,7 @@ const {
   guidelines,
   getAvailableCollectionLabels,
   getAvailableTextLabels,
-  getCollectionFields,
+  getCollectionConfigFields,
   initializeGuidelines,
 } = useGuidelinesStore();
 
@@ -73,9 +73,9 @@ const availableTextLabels = computed(getAvailableTextLabels);
 // TODO: Still a workaround, should be mady dynamic.
 const fields: ComputedRef<CollectionProperty[]> = computed(() => {
   if (collectionAccessObject.value.collection.nodeLabels.includes('Letter')) {
-    return guidelines.value ? getCollectionFields('text') : [];
+    return guidelines.value ? getCollectionConfigFields('Letter') : [];
   } else {
-    return guidelines.value ? getCollectionFields('comment') : [];
+    return guidelines.value ? getCollectionConfigFields('Comment') : [];
   }
 });
 

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -9,7 +9,13 @@ import {
 import { useGuidelinesStore } from '../store/guidelines';
 import CollectionError from '../components/CollectionError.vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
-import { areObjectsEqual, buildFetchUrl, capitalize, cloneDeep } from '../utils/helper/helper';
+import {
+  areObjectsEqual,
+  areSetsEqual,
+  buildFetchUrl,
+  capitalize,
+  cloneDeep,
+} from '../utils/helper/helper';
 import { IGuidelines } from '../models/IGuidelines';
 import {
   CollectionAccessObject,
@@ -208,7 +214,15 @@ async function handleSaveChanges(): Promise<void> {
 }
 
 function hasUnsavedChanges(): boolean {
-  // TODO: When Collection labels should be editable, this needs to be catched here
+  // Compare collection node labels
+  if (
+    !areSetsEqual(
+      new Set(collectionAccessObject.value.collection.nodeLabels),
+      new Set(initialCollectionAccessObject.value.collection.nodeLabels),
+    )
+  ) {
+    return true;
+  }
 
   // Compare collection properties
   if (

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -41,7 +41,8 @@ type TextTableEntry = {
 const route: RouteLocationNormalizedLoaded = useRoute();
 const toast: ToastServiceMethods = useToast();
 const confirm = useConfirm();
-const { guidelines, getAvailableTextLabels, initializeGuidelines } = useGuidelinesStore();
+const { guidelines, getAvailableTextLabels, getCollectionFields, initializeGuidelines } =
+  useGuidelinesStore();
 
 const collectionUuid: string = route.params.uuid as string;
 
@@ -60,9 +61,9 @@ const availableTextLabels = computed(getAvailableTextLabels);
 // TODO: Still a workaround, should be mady dynamic.
 const fields: ComputedRef<CollectionProperty[]> = computed(() => {
   if (collectionAccessObject.value.collection.nodeLabels.includes('Letter')) {
-    return guidelines.value ? guidelines.value.collections['text'].properties : [];
+    return guidelines.value ? getCollectionFields('text') : [];
   } else {
-    return guidelines.value ? guidelines.value.collections['comment'].properties : [];
+    return guidelines.value ? getCollectionFields('comment') : [];
   }
 });
 

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -41,8 +41,13 @@ type TextTableEntry = {
 const route: RouteLocationNormalizedLoaded = useRoute();
 const toast: ToastServiceMethods = useToast();
 const confirm = useConfirm();
-const { guidelines, getAvailableTextLabels, getCollectionFields, initializeGuidelines } =
-  useGuidelinesStore();
+const {
+  guidelines,
+  getAvailableCollectionLabels,
+  getAvailableTextLabels,
+  getCollectionFields,
+  initializeGuidelines,
+} = useGuidelinesStore();
 
 const collectionUuid: string = route.params.uuid as string;
 
@@ -56,6 +61,7 @@ const isLoading = ref<boolean>(true);
 // For fetch during save/cancel action
 const asyncOperationRunning = ref<boolean>(false);
 
+const availableCollectionLabels = computed(getAvailableCollectionLabels);
 const availableTextLabels = computed(getAvailableTextLabels);
 
 // TODO: Still a workaround, should be mady dynamic.
@@ -378,6 +384,33 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
     >
       <SplitterPanel :size="10" class="overflow-y-auto">
         <div class="properties-pane w-full">
+          <h2 class="text-center">Collection labels</h2>
+          <div v-if="mode === 'edit'" class="flex justify-content-center">
+            <MultiSelect
+              v-model="collectionAccessObject.collection.nodeLabels"
+              :options="availableCollectionLabels"
+              display="chip"
+              placeholder="Select labels"
+              :filter="false"
+            >
+              <template #chip="{ value }">
+                <Tag :value="value" severity="contrast" class="mr-1" />
+              </template>
+            </MultiSelect>
+          </div>
+          <div v-else class="flex gap-2 justify-content-center">
+            <template
+              v-if="collectionAccessObject.collection.nodeLabels.length > 0"
+              v-for="label in collectionAccessObject.collection.nodeLabels"
+              :key="label"
+            >
+              <Tag :value="label" severity="contrast" class="mr-1" />
+            </template>
+            <div v-else>
+              <i>This Collection has no labels yet.</i>
+            </div>
+          </div>
+
           <h2 class="text-center">Properties</h2>
           <form>
             <div class="flex align-items-center gap-3 mb-3">

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -73,9 +73,9 @@ const availableTextLabels = computed(getAvailableTextLabels);
 // TODO: Still a workaround, should be mady dynamic.
 const fields: ComputedRef<CollectionProperty[]> = computed(() => {
   if (collectionAccessObject.value.collection.nodeLabels.includes('Letter')) {
-    return guidelines.value ? getCollectionConfigFields('Letter') : [];
+    return guidelines.value ? getCollectionConfigFields(['Letter']) : [];
   } else {
-    return guidelines.value ? getCollectionConfigFields('Comment') : [];
+    return guidelines.value ? getCollectionConfigFields(['Comment']) : [];
   }
 });
 

--- a/server/src/config/guidelines.json
+++ b/server/src/config/guidelines.json
@@ -18,6 +18,7 @@
     "types": [
       {
         "additionalLabel": "Letter",
+        "level": "primary",
         "properties": [
           {
             "name": "status",
@@ -44,6 +45,7 @@
       },
       {
         "additionalLabel": "Comment",
+        "level": "secondary",
         "properties": []
       }
     ]

--- a/server/src/config/guidelines.json
+++ b/server/src/config/guidelines.json
@@ -2,8 +2,9 @@
   "texts": {
     "additionalLabels": ["CommentText", "LetterText"]
   },
-  "collections": {
-    "text": {
+  "collections": [
+    {
+      "type": "text",
       "additionalLabel": "Letter",
       "properties": [
         {
@@ -36,7 +37,8 @@
         }
       ]
     },
-    "comment": {
+    {
+      "type": "comment",
       "additionalLabel": "Comment",
       "properties": [
         {
@@ -48,7 +50,7 @@
         }
       ]
     }
-  },
+  ],
   "annotations": {
     "types": [
       {

--- a/server/src/config/guidelines.json
+++ b/server/src/config/guidelines.json
@@ -2,55 +2,52 @@
   "texts": {
     "additionalLabels": ["CommentText", "LetterText"]
   },
-  "collections": [
-    {
-      "type": "text",
-      "additionalLabel": "Letter",
-      "properties": [
+  "collections": {
+    "properties": {
+      "system": [
         {
           "name": "label",
           "type": "text",
           "required": true,
           "editable": true,
           "visible": false
-        },
-        {
-          "name": "status",
-          "type": "text",
-          "required": false,
-          "editable": true,
-          "visible": true
-        },
-        {
-          "name": "sender",
-          "type": "text",
-          "required": false,
-          "editable": true,
-          "visible": true
-        },
-        {
-          "name": "receiver",
-          "type": "text",
-          "required": false,
-          "editable": true,
-          "visible": true
         }
-      ]
+      ],
+      "base": []
     },
-    {
-      "type": "comment",
-      "additionalLabel": "Comment",
-      "properties": [
-        {
-          "name": "label",
-          "type": "text",
-          "required": true,
-          "editable": false,
-          "visible": false
-        }
-      ]
-    }
-  ],
+    "types": [
+      {
+        "additionalLabel": "Letter",
+        "properties": [
+          {
+            "name": "status",
+            "type": "text",
+            "required": false,
+            "editable": true,
+            "visible": true
+          },
+          {
+            "name": "sender",
+            "type": "text",
+            "required": false,
+            "editable": true,
+            "visible": true
+          },
+          {
+            "name": "receiver",
+            "type": "text",
+            "required": false,
+            "editable": true,
+            "visible": true
+          }
+        ]
+      },
+      {
+        "additionalLabel": "Comment",
+        "properties": []
+      }
+    ]
+  },
   "annotations": {
     "types": [
       {

--- a/server/src/models/IGuidelines.ts
+++ b/server/src/models/IGuidelines.ts
@@ -7,10 +7,15 @@ import {
 
 export interface IGuidelines {
   collections: {
-    type: string;
-    additionalLabel: string /* "Letter" etc. */;
-    properties: CollectionProperty[];
-  }[];
+    properties: {
+      system: CollectionProperty[];
+      base: CollectionProperty[];
+    };
+    types: {
+      additionalLabel: string;
+      properties: CollectionProperty[];
+    }[];
+  };
   annotations: {
     additionalTexts: string[];
     types: AnnotationType[];

--- a/server/src/models/IGuidelines.ts
+++ b/server/src/models/IGuidelines.ts
@@ -13,6 +13,9 @@ export interface IGuidelines {
     };
     types: {
       additionalLabel: string;
+      level:
+        | 'primary'
+        | 'secondary' /* Quick fix to determine which collections should be loaded into the overview table */;
       properties: CollectionProperty[];
     }[];
   };

--- a/server/src/models/IGuidelines.ts
+++ b/server/src/models/IGuidelines.ts
@@ -7,11 +7,10 @@ import {
 
 export interface IGuidelines {
   collections: {
-    [index: string] /* letter, document etc. */ : {
-      additionalLabel: string /* "Letter" etc. */;
-      properties: CollectionProperty[];
-    };
-  };
+    type: string;
+    additionalLabel: string /* "Letter" etc. */;
+    properties: CollectionProperty[];
+  }[];
   annotations: {
     additionalTexts: string[];
     types: AnnotationType[];

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -15,12 +15,16 @@ const guidelineService: GuidelinesService = new GuidelinesService();
 router.get('/', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const guidelines: IGuidelines = await guidelineService.getGuidelines();
-    // TODO: Catch when collection config is not found (empty string will throw errors)
-    const additionalLabel =
-      guidelines.collections.types.find(c => c.additionalLabel === 'Letter')?.additionalLabel ?? '';
+
+    // Get Collection type that is shown in the table and does not only exist as anchor to additional text
+    // Needs to be overhauled anyway when whole hierarchies should be handled in the future
+    // Careful, a collection with level "primary" MUST exist in the guidelines with this solution
+    const primaryCollectionLabel = guidelines.collections.types.find(
+      t => t.level === 'primary',
+    )!.additionalLabel;
 
     const collections: CollectionAccessObject[] =
-      await collectionService.getCollectionsWithTexts(additionalLabel);
+      await collectionService.getCollectionsWithTexts(primaryCollectionLabel);
 
     res.status(200).json(collections);
   } catch (error: unknown) {

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -17,7 +17,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
     const guidelines: IGuidelines = await guidelineService.getGuidelines();
     // TODO: Catch when collection config is not found (empty string will throw errors)
     const additionalLabel =
-      guidelines.collections.find(c => c.additionalLabel === 'Letter')?.additionalLabel ?? '';
+      guidelines.collections.types.find(c => c.additionalLabel === 'Letter')?.additionalLabel ?? '';
 
     const collections: CollectionAccessObject[] =
       await collectionService.getCollectionsWithTexts(additionalLabel);

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -17,7 +17,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
     const guidelines: IGuidelines = await guidelineService.getGuidelines();
     // TODO: Catch when collection config is not found (empty string will throw errors)
     const additionalLabel =
-      guidelines.collections.find(c => c.type === 'text')?.additionalLabel ?? '';
+      guidelines.collections.find(c => c.additionalLabel === 'Letter')?.additionalLabel ?? '';
 
     const collections: CollectionAccessObject[] =
       await collectionService.getCollectionsWithTexts(additionalLabel);

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -15,7 +15,9 @@ const guidelineService: GuidelinesService = new GuidelinesService();
 router.get('/', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const guidelines: IGuidelines = await guidelineService.getGuidelines();
-    const additionalLabel = guidelines.collections['text'].additionalLabel;
+    // TODO: Catch when collection config is not found (empty string will throw errors)
+    const additionalLabel =
+      guidelines.collections.find(c => c.type === 'text')?.additionalLabel ?? '';
 
     const collections: CollectionAccessObject[] =
       await collectionService.getCollectionsWithTexts(additionalLabel);
@@ -31,7 +33,9 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
 
   try {
     const guidelines: IGuidelines = await guidelineService.getGuidelines();
-    const additionalLabel = guidelines.collections['text'].additionalLabel;
+    // TODO: Catch when collection config is not found (empty string will throw errors)
+    const additionalLabel =
+      guidelines.collections.find(c => c.type === 'text')?.additionalLabel ?? '';
 
     const newCollection: ICollection = await collectionService.createNewCollection(
       data,

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -5,7 +5,7 @@ import CollectionService from '../services/collection.service.js';
 import GuidelinesService from '../services/guidelines.service.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
-import { CollectionAccessObject, CollectionPostData } from '../models/types.js';
+import { Collection, CollectionAccessObject, CollectionPostData } from '../models/types.js';
 
 const router: Router = express.Router({ mergeParams: true });
 
@@ -29,17 +29,12 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
 });
 
 router.post('/', async (req: Request, res: Response, next: NextFunction) => {
-  const data: Record<string, string> = { ...req.body };
+  const { data, nodeLabels }: Collection = req.body;
 
   try {
-    const guidelines: IGuidelines = await guidelineService.getGuidelines();
-    // TODO: Catch when collection config is not found (empty string will throw errors)
-    const additionalLabel =
-      guidelines.collections.find(c => c.type === 'text')?.additionalLabel ?? '';
-
     const newCollection: ICollection = await collectionService.createNewCollection(
       data,
-      additionalLabel,
+      nodeLabels,
     );
 
     res.status(201).json(newCollection);

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -148,9 +148,9 @@ export default class CollectionService {
   public async createNewCollection(data: ICollection, labels: string[]): Promise<ICollection> {
     const guidelineService: GuidelinesService = new GuidelinesService();
 
-    // TODO: Fields need to match the given Label or even a combination of them
-    const requiredFields: CollectionProperty[] =
-      await guidelineService.getCollectionConfigFields('Letter');
+    const requiredFields: CollectionProperty[] = await guidelineService.getCollectionConfigFields([
+      'Letter',
+    ]);
 
     // Add default properties if they are not sent in the request
     requiredFields.forEach(property => {

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -4,7 +4,12 @@ import GuidelinesService from './guidelines.service.js';
 import NotFoundError from '../errors/not-found.error.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
-import { CollectionAccessObject, CollectionPostData, Text } from '../models/types.js';
+import {
+  CollectionAccessObject,
+  CollectionPostData,
+  CollectionProperty,
+  Text,
+} from '../models/types.js';
 
 type CollectionTextObject = {
   all: Text[];
@@ -145,10 +150,11 @@ export default class CollectionService {
     additionalLabel: string,
   ): Promise<ICollection> {
     const guidelineService: GuidelinesService = new GuidelinesService();
-    const guidelines: IGuidelines = await guidelineService.getGuidelines();
+
+    const requiredFields: CollectionProperty[] = await guidelineService.getCollectionFields('text');
 
     // Add default properties if they are not sent in the request
-    guidelines.collections['text'].properties.forEach(property => {
+    requiredFields.forEach(property => {
       if (!data[property.name]) {
         data[property.name] = '';
       }

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -214,6 +214,11 @@ export default class CollectionService {
     
     SET c = $collection.data
 
+    WITH c, [l IN labels(c) WHERE l <> 'Collection'] AS labelsToRemove
+
+    CALL apoc.create.removeLabels(c, labelsToRemove) YIELD node AS nodeBefore
+    CALL apoc.create.addLabels(c, $collection.nodeLabels) YIELD node AS nodeAfter
+
     WITH c
 
     // Delete Text nodes

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -149,7 +149,8 @@ export default class CollectionService {
     const guidelineService: GuidelinesService = new GuidelinesService();
 
     // TODO: Fields need to match the given Label or even a combination of them
-    const requiredFields: CollectionProperty[] = await guidelineService.getCollectionFields('text');
+    const requiredFields: CollectionProperty[] =
+      await guidelineService.getCollectionConfigFields('Letter');
 
     // Add default properties if they are not sent in the request
     requiredFields.forEach(property => {

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -139,36 +139,38 @@ export default class CollectionService {
   }
 
   /**
-   * Creates a new collection node with given data as properties.
+   * Creates a new collection node with the given properties and labels.
    *
-   * @param {Record<string, string>} data - JSON data for the new collection node.
-   * @return {Promise<ICollection>} A promise that resolves to the newly created collection.
+   * Adds default values for required properties if they are not provided.
+   *
+   * @param {ICollection} data - The data to set for the collection node.
+   * @param {string[]} nodeLabels - The additional labels to add to the collection node.
+   * @throws {NotFoundError} If the collection with the specified UUID is not found.
+   * @return {Promise<ICollection>} A promise that resolves to the created collection node.
    */
-  // TODO: Make additional label(s) dynamic
-  public async createNewCollection(data: ICollection, labels: string[]): Promise<ICollection> {
+  public async createNewCollection(data: ICollection, nodeLabels: string[]): Promise<ICollection> {
     const guidelineService: GuidelinesService = new GuidelinesService();
 
-    const requiredFields: CollectionProperty[] = await guidelineService.getCollectionConfigFields([
-      'Letter',
-    ]);
+    const requiredFields: CollectionProperty[] =
+      await guidelineService.getCollectionConfigFields(nodeLabels);
 
     // Add default properties if they are not sent in the request
     requiredFields.forEach(property => {
-      if (!data[property.name]) {
+      if (!(property.name in data)) {
         data[property.name] = '';
       }
     });
 
     data = { ...data, uuid: crypto.randomUUID() };
 
-    labels.push('Collection');
+    nodeLabels.push('Collection');
 
     const query: string = `
-    CALL apoc.create.node($labels, $data) YIELD node as c
+    CALL apoc.create.node($nodeLabels, $data) YIELD node as c
     RETURN c {.*} AS collection
     `;
 
-    const result: QueryResult = await Neo4jDriver.runQuery(query, { data, labels });
+    const result: QueryResult = await Neo4jDriver.runQuery(query, { data, nodeLabels });
 
     return result.records[0]?.get('collection');
   }

--- a/server/src/services/guidelines.service.ts
+++ b/server/src/services/guidelines.service.ts
@@ -6,16 +6,28 @@ import { CollectionProperty } from '../models/types.js';
 
 export default class GuidelinesService {
   /**
-   * Retrieves field configuration of a collection with given additional node label. Contains information about validation rules (required/not required).
+   * Retrieves field configuration of a collection with given additional node labels. Contains information about validation rules (required/not required).
    * Used for applying default data to to-be-created collections when they are missing
    *
-   * @param {string} nodeLabel - The additional label of the collection.
+   * @param {string[]} nodeLabels - The additional labels of the collection.
    * @return {Promise<CollectionProperty[]>} The field configurations for the collection type.
    */
-  public async getCollectionConfigFields(nodeLabel: string): Promise<CollectionProperty[]> {
+  public async getCollectionConfigFields(nodeLabels: string[]): Promise<CollectionProperty[]> {
     const guidelines: IGuidelines = await this.getGuidelines();
 
-    return guidelines.collections.find(c => c.additionalLabel === nodeLabel)?.properties ?? [];
+    const system: CollectionProperty[] = guidelines.collections.properties.system;
+    const base: CollectionProperty[] = guidelines.collections.properties.base;
+    const additional: CollectionProperty[] = guidelines.collections.types.reduce(
+      (total: CollectionProperty[], curr) => {
+        if (nodeLabels.includes(curr.additionalLabel)) {
+          total.push(...curr.properties);
+        }
+        return total;
+      },
+      [],
+    );
+
+    return [...system, ...base, ...additional];
   }
 
   /**

--- a/server/src/services/guidelines.service.ts
+++ b/server/src/services/guidelines.service.ts
@@ -2,8 +2,22 @@ import { promises as fs } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 import { IGuidelines } from '../models/IGuidelines.js';
+import { CollectionProperty } from '../models/types.js';
 
 export default class GuidelinesService {
+  /**
+   * Retrieves field configuration of a collection of given type. Contains information about validation rules (required/not required).
+   * Used for applying default data to to-be-created collections when they are missing
+   *
+   * @param {string} type - The type of the collection.
+   * @return {Promise<CollectionProperty[]>} The field configurations for the collection type.
+   */
+  public async getCollectionFields(type: string): Promise<CollectionProperty[]> {
+    const guidelines: IGuidelines = await this.getGuidelines();
+
+    return guidelines.collections.find(c => c.type === type)?.properties ?? [];
+  }
+
   /**
    * Retrieves the Edition guidelines from a JSON file.
    *

--- a/server/src/services/guidelines.service.ts
+++ b/server/src/services/guidelines.service.ts
@@ -6,16 +6,16 @@ import { CollectionProperty } from '../models/types.js';
 
 export default class GuidelinesService {
   /**
-   * Retrieves field configuration of a collection of given type. Contains information about validation rules (required/not required).
+   * Retrieves field configuration of a collection with given additional node label. Contains information about validation rules (required/not required).
    * Used for applying default data to to-be-created collections when they are missing
    *
-   * @param {string} type - The type of the collection.
+   * @param {string} nodeLabel - The additional label of the collection.
    * @return {Promise<CollectionProperty[]>} The field configurations for the collection type.
    */
-  public async getCollectionFields(type: string): Promise<CollectionProperty[]> {
+  public async getCollectionConfigFields(nodeLabel: string): Promise<CollectionProperty[]> {
     const guidelines: IGuidelines = await this.getGuidelines();
 
-    return guidelines.collections.find(c => c.type === type)?.properties ?? [];
+    return guidelines.collections.find(c => c.additionalLabel === nodeLabel)?.properties ?? [];
   }
 
   /**

--- a/server/src/services/text.service.ts
+++ b/server/src/services/text.service.ts
@@ -31,7 +31,6 @@ export default class TextService {
    * @return {Promise<TextAccessObject>} A promise that resolves to the retrieved extended text.
    */
   public async getExtendedTextByUuid(uuid: string): Promise<TextAccessObject> {
-    // TODO: "Letter" label should be made dynamic
     const query: string = `
     MATCH (t:Text {uuid: $uuid})
     MATCH (t)-[:PART_OF]->(c:Collection)

--- a/server/src/services/text.service.ts
+++ b/server/src/services/text.service.ts
@@ -36,7 +36,9 @@ export default class TextService {
     MATCH (t:Text {uuid: $uuid})
     WITH t
     MATCH (t)-[:PART_OF]->(c:Collection)
-    MATCH p = (t)-[:HAS_TEXT | REFERS_TO | HAS_ANNOTATION | PART_OF*]-(:Collection:Letter)
+    MATCH p = (t)-[:HAS_TEXT | REFERS_TO | HAS_ANNOTATION | PART_OF*]-(cStart:Collection)
+    WHERE NOT ()-[:REFERS_TO]->(cStart)
+    AND NOT ()<-[:PART_OF]-(cStart)
 
     RETURN {
         text: {

--- a/server/src/services/text.service.ts
+++ b/server/src/services/text.service.ts
@@ -34,7 +34,6 @@ export default class TextService {
     // TODO: "Letter" label should be made dynamic
     const query: string = `
     MATCH (t:Text {uuid: $uuid})
-    WITH t
     MATCH (t)-[:PART_OF]->(c:Collection)
     MATCH p = (t)-[:HAS_TEXT | REFERS_TO | HAS_ANNOTATION | PART_OF*]-(cStart:Collection)
     WHERE NOT ()-[:REFERS_TO]->(cStart)


### PR DESCRIPTION
Make additional node labels that that can be set on Collection nodes dynamic instead of using `Letter` as default label for everything. Additional labels can be set, removed and combined as wished.

Key changes:

- Restructuring of the guidelines to use `Letter` as one of the available node labels
- Add preliminary `level` entry to each Collection to indicate whether they should be shown as entry in the overview table (WIP, will change in the future)
- Remove hardcoded "Letter" references in codebase
- Differentiate between property configurations for Collection nodes (will change later)
  -  `system`: Default properties that all Collection nodes must have
  - `base`: Default properties for Collection nodes that can be customized
  - `properties` for each additional Collection type: Nodes that extend the Collection nodes (`Letter`, `Comment` etc.) can have their own properties (`Letter` -> `sentBy`, `receivedBy` etc.)
- Add methods to guidelines stores and classes to handle this functionality
- Render input fields for Collections dynamically depending on the selected node labels (creating, updating)
