### PR TITLE
Fetch annotation stylesheet from external source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,4 @@ NEO4J_URI="<bolt://neo4j:7687>" # Connection URI for neo4j driver. Adjust for de
 NEO4J_USER="<neo4j user>"
 NODE_ENV="development | production"
 PROTOCOL="http | https" # temporary workaround, should be https per default later
+STYLESHEET_URL="<url-to-stylesheet.css>" # URL to the stylesheet for the annotations in the editor

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -7,7 +7,6 @@ import ToastService from 'primevue/toastservice';
 import App from './App.vue';
 import router from './router.ts';
 import '../src/styles/style.css';
-// import '../src/styles/annotations.css';
 import '../src/styles/variables.css';
 import 'primeicons/primeicons.css';
 import '/node_modules/primeflex/primeflex.css';

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -7,7 +7,7 @@ import ToastService from 'primevue/toastservice';
 import App from './App.vue';
 import router from './router.ts';
 import '../src/styles/style.css';
-import '../src/styles/annotations.css';
+// import '../src/styles/annotations.css';
 import '../src/styles/variables.css';
 import 'primeicons/primeicons.css';
 import '/node_modules/primeflex/primeflex.css';

--- a/client/src/views/Editor.vue
+++ b/client/src/views/Editor.vue
@@ -46,6 +46,7 @@ onMounted(async (): Promise<void> => {
     await getGuidelines();
     await getCharacters();
     await getAnnotations();
+    await getAnnotationStyles();
 
     // initializeHistory();
 
@@ -324,6 +325,27 @@ async function getGuidelines(): Promise<void> {
     initializeGuidelines(fetchedGuidelines);
   } catch (error: unknown) {
     console.error('Error fetching guidelines:', error);
+  }
+}
+
+async function getAnnotationStyles() {
+  try {
+    const url: string = buildFetchUrl('/api/styles');
+    const response: Response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error('Failed to load stylesheet');
+    }
+
+    const styles: string = await response.text();
+    const styleTag: HTMLStyleElement = document.createElement('style');
+
+    styleTag.id = 'custom-styles';
+    styleTag.innerHTML = styles;
+
+    document.head.appendChild(styleTag);
+  } catch (error) {
+    console.error('Error loading stylesheet:', error);
   }
 }
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,6 +46,7 @@ services:
    - NEO4J_PW=${NEO4J_PW}
    - NODE_ENV=${NODE_ENV}
    - PROTOCOL=${PROTOCOL}
+   - STYLESHEET_URL=${STYLESHEET_URL}
   depends_on:
    neo4j:
     condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
    - NEO4J_PW=${NEO4J_PW}
    - NODE_ENV=${NODE_ENV}
    - PROTOCOL=${PROTOCOL}
+   - STYLESHEET_URL=${STYLESHEET_URL}
   depends_on:
    - neo4j
 

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2,6 +2,7 @@ import express, { Router } from 'express';
 import collectionRoutes from './collections.routes.js';
 import guideLinesRoutes from './guidelines.routes.js';
 import resourceRoutes from './resources.routes.js';
+import stylesRoutes from './styles.routes.js';
 import textRoutes from './text.routes.js';
 
 const router: Router = express.Router();
@@ -9,6 +10,7 @@ const router: Router = express.Router();
 router.use('/collections', collectionRoutes);
 router.use('/guidelines', guideLinesRoutes);
 router.use('/resources', resourceRoutes);
+router.use('/styles', stylesRoutes);
 router.use('/texts', textRoutes);
 
 export default router;

--- a/server/src/routes/styles.routes.ts
+++ b/server/src/routes/styles.routes.ts
@@ -1,0 +1,18 @@
+import express, { NextFunction, Request, Response, Router } from 'express';
+import StylesService from '../services/styles.service.js';
+
+const router: Router = express.Router();
+
+const styleService: StylesService = new StylesService();
+
+router.get('/', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const styles: string = await styleService.getStyles();
+
+    res.setHeader('Content-Type', 'text/css').status(200).send(styles);
+  } catch (error: unknown) {
+    next(error);
+  }
+});
+
+export default router;

--- a/server/src/services/styles.service.ts
+++ b/server/src/services/styles.service.ts
@@ -1,0 +1,28 @@
+import NotFoundError from '../errors/not-found.error.js';
+
+export default class StylesService {
+  /**
+   * Retrieves the stylesheet from the URL defined in the STYLESHEET_URL environment variable.
+   *
+   * @throws {NotFoundError} If the URL is not provided or if the stylesheet could not be loaded.
+   * @return {Promise<string>} The retrieved stylesheet.
+   */
+  public async getStyles(): Promise<string> {
+    // TODO: Improve error handling...
+    const url: string | undefined = process.env.STYLESHEET_URL;
+
+    if (!url) {
+      throw new NotFoundError(`URL to stylesheet is not provided...`);
+    }
+
+    const response: Response = await fetch(url);
+
+    if (!response.ok) {
+      throw new NotFoundError(`Styles could not be loaded`);
+    }
+
+    const styles: string = await response.text();
+
+    return styles;
+  }
+}

--- a/server/src/services/styles.service.ts
+++ b/server/src/services/styles.service.ts
@@ -5,7 +5,7 @@ export default class StylesService {
    * Retrieves the stylesheet from the URL defined in the STYLESHEET_URL environment variable.
    *
    * @throws {NotFoundError} If the URL is not provided or if the stylesheet could not be loaded.
-   * @return {Promise<string>} The retrieved stylesheet.
+   * @return {Promise<string>} The retrieved stylesheet as raw CSS.
    */
   public async getStyles(): Promise<string> {
     // TODO: Improve error handling...


### PR DESCRIPTION
The location of the stylesheet for annotations in the text should not be hardcoded but adjustable by each project. Resembles PR #16 where the same behaviour was implemented for the guidelines.json file.

Key changes:

- Added STYLESHEET_URL entry in the `.env` file that points to the web resource that contains the CSS for the annotations in the text.
- Backend service fetches stylesheet (CSS) from the given source instead of the repo directly.
- Frontend inserts the incoming CSS into a custom HTML `<style>` tag of the page.