### PR TITLE
Server side pagination for collection table

### DIFF
--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -8,7 +8,7 @@ import Column from 'primevue/column';
 import DataTable, { DataTablePageEvent, DataTableSortEvent } from 'primevue/datatable';
 import { Tag } from 'primevue';
 import { IGuidelines } from '../models/IGuidelines';
-import { CollectionAccessObject, CollectionProperty } from '../models/types';
+import { CollectionAccessObject, CollectionProperty, PaginationData } from '../models/types';
 
 type CollectionTableEntry = {
   [key: string | keyof CollectionProperty]: unknown;
@@ -16,6 +16,7 @@ type CollectionTableEntry = {
 
 const props = defineProps<{
   collections: CollectionAccessObject[] | null;
+  pagination: PaginationData | null;
 }>();
 
 const emit = defineEmits(['paginationChanged', 'sortChanged']);
@@ -98,7 +99,9 @@ async function getGuidelines(): Promise<void> {
       scrollHeight="flex"
       :value="tableData"
       paginator
+      lazy
       :rows="5"
+      :totalRecords="props.pagination.totalRecords"
       :rowsPerPageOptions="[5, 10, 20, 50, 100]"
       removableSort
       resizableColumns

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -14,6 +14,11 @@ type CollectionTableEntry = {
   [key: string | keyof CollectionProperty]: unknown;
 };
 
+type ColumnConfig = {
+  name: string;
+  isSortable: boolean;
+};
+
 const props = defineProps<{
   collections: CollectionAccessObject[] | null;
   pagination: PaginationData | null;
@@ -22,7 +27,8 @@ const props = defineProps<{
 const emit = defineEmits(['paginationChanged', 'sortChanged']);
 
 const { guidelines, getCollectionConfigFields } = useGuidelinesStore();
-const columns = ref<string[]>([]);
+
+const columns = ref<ColumnConfig[]>([]);
 
 const tableData: ComputedRef<CollectionTableEntry[]> = computed(() => {
   return props?.collections?.map(collection => {
@@ -39,15 +45,18 @@ onMounted(async (): Promise<void> => {
 
   // Get Collection type that is shown in the table and does not only exist as anchor to additional text
   // Needs to be overhauled anyway when whole hierarchies should be handled in the future
-  const primaryCollectionLabel = guidelines.value.collections.types.find(
+  const primaryCollectionLabel: string = guidelines.value.collections.types.find(
     t => t.level === 'primary',
   )?.additionalLabel;
 
   // TODO: This approach is bad since possible data keys are reserved...
   columns.value = [
-    'nodeLabels',
-    ...getCollectionConfigFields([primaryCollectionLabel]).map(f => f.name),
-    'texts',
+    { name: 'nodeLabels', isSortable: false },
+    ...getCollectionConfigFields([primaryCollectionLabel]).map(f => ({
+      name: f.name,
+      isSortable: true,
+    })),
+    { name: 'texts', isSortable: false },
   ];
 });
 
@@ -115,24 +124,24 @@ async function getGuidelines(): Promise<void> {
     >
       <Column
         v-for="col of columns"
-        :key="col"
-        :field="col"
-        :header="capitalize(col)"
-        sortable
-        :headerStyle="`width: ${getColumnWidth(col)}`"
+        :key="col.name"
+        :field="col.name"
+        :header="capitalize(col.name)"
+        :sortable="col.isSortable"
+        :headerStyle="`width: ${getColumnWidth(col.name)}`"
       >
         <template #body="{ data }">
           <!-- TODO: This should come from the configuration... -->
           <!-- TODO: Bit hacky. Beautify? -->
           <RouterLink
-            v-if="col === 'label'"
+            v-if="col.name === 'label'"
             class="cell-link"
             :to="`/collections/${data.uuid}`"
-            v-tooltip.hover.top="{ value: data[col], showDelay: 0 }"
-            >{{ data[col] }}</RouterLink
+            v-tooltip.hover.top="{ value: data[col.name], showDelay: 0 }"
+            >{{ data[col.name] }}</RouterLink
           >
-          <span v-else-if="col === 'texts'" class="cell-info">{{ data[col] }}</span>
-          <span v-else-if="col === 'nodeLabels'" class="cell-info">
+          <span v-else-if="col.name === 'texts'" class="cell-info">{{ data[col.name] }}</span>
+          <span v-else-if="col.name === 'nodeLabels'" class="cell-info">
             <div class="box flex" style="flex-wrap: wrap">
               <Tag
                 v-for="label in data.nodeLabels"
@@ -142,9 +151,12 @@ async function getGuidelines(): Promise<void> {
               />
             </div>
           </span>
-          <span v-else class="cell-info" v-tooltip.hover.top="{ value: data[col], showDelay: 0 }">{{
-            data[col]
-          }}</span>
+          <span
+            v-else
+            class="cell-info"
+            v-tooltip.hover.top="{ value: data[col.name], showDelay: 0 }"
+            >{{ data[col.name] }}</span
+          >
         </template>
       </Column>
     </DataTable>

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -109,8 +109,8 @@ async function getGuidelines(): Promise<void> {
       :value="tableData"
       paginator
       lazy
-      :rows="5"
-      :totalRecords="props.pagination.totalRecords"
+      :rows="pagination?.limit || 0"
+      :totalRecords="pagination?.totalRecords || 0"
       :rowsPerPageOptions="[5, 10, 20, 50, 100]"
       removableSort
       resizableColumns

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -22,6 +22,7 @@ type ColumnConfig = {
 const props = defineProps<{
   collections: CollectionAccessObject[] | null;
   pagination: PaginationData | null;
+  asyncOperationRunning: boolean;
 }>();
 
 const emit = defineEmits(['paginationChanged', 'sortChanged']);
@@ -121,6 +122,13 @@ async function getGuidelines(): Promise<void> {
       size="small"
       @sort="handleSort"
       @page="handlePagination"
+      :pt="{
+        tbody: {
+          style: {
+            opacity: asyncOperationRunning ? 0.5 : 'unset',
+          },
+        },
+      }"
     >
       <Column
         v-for="col of columns"

--- a/client/src/components/OverviewCollectionTable.vue
+++ b/client/src/components/OverviewCollectionTable.vue
@@ -5,7 +5,7 @@ import { useGuidelinesStore } from '../store/guidelines';
 import LoadingSpinner from './LoadingSpinner.vue';
 import { buildFetchUrl, capitalize } from '../utils/helper/helper';
 import Column from 'primevue/column';
-import DataTable from 'primevue/datatable';
+import DataTable, { DataTablePageEvent, DataTableSortEvent } from 'primevue/datatable';
 import { Tag } from 'primevue';
 import { IGuidelines } from '../models/IGuidelines';
 import { CollectionAccessObject, CollectionProperty } from '../models/types';
@@ -17,6 +17,8 @@ type CollectionTableEntry = {
 const props = defineProps<{
   collections: CollectionAccessObject[] | null;
 }>();
+
+const emit = defineEmits(['paginationChanged', 'sortChanged']);
 
 const { guidelines, getCollectionConfigFields } = useGuidelinesStore();
 const columns = ref<string[]>([]);
@@ -59,6 +61,14 @@ function getColumnWidth(columnName: string): string {
   }
 }
 
+function handleSort(event: DataTableSortEvent): void {
+  emit('sortChanged', event);
+}
+
+function handlePagination(event: DataTablePageEvent): void {
+  emit('paginationChanged', event);
+}
+
 // TODO: getGuidelines exists in multiple components now, should be moved to a shared location
 async function getGuidelines(): Promise<void> {
   try {
@@ -88,8 +98,8 @@ async function getGuidelines(): Promise<void> {
       scrollHeight="flex"
       :value="tableData"
       paginator
-      :rows="10"
-      :rowsPerPageOptions="[10, 20, 50, 100]"
+      :rows="5"
+      :rowsPerPageOptions="[5, 10, 20, 50, 100]"
       removableSort
       resizableColumns
       rowHover
@@ -97,6 +107,8 @@ async function getGuidelines(): Promise<void> {
       paginatorTemplate="RowsPerPageDropdown FirstPageLink PrevPageLink PageLinks  NextPageLink LastPageLink CurrentPageReport"
       currentPageReportTemplate="{first} to {last} of {totalRecords}"
       size="small"
+      @sort="handleSort"
+      @page="handlePagination"
     >
       <Column
         v-for="col of columns"

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -111,6 +111,20 @@ export type MalformedAnnotation = {
   data: StandoffAnnotation;
 };
 
+export type PaginationData = {
+  limit: number;
+  order: string;
+  search: string;
+  skip: number;
+  sort: string;
+  totalRecords: number;
+};
+
+export type PaginationResult<T> = {
+  data: T;
+  pagination: PaginationData;
+};
+
 export type StandoffAnnotation = {
   [key: string]: string | number | boolean;
   start: number;

--- a/client/src/views/Overview.vue
+++ b/client/src/views/Overview.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, onMounted, watch, computed } from 'vue';
+import { refDebounced } from '@vueuse/core';
 import Toast from 'primevue/toast';
 import { ToastServiceMethods } from 'primevue/toastservice';
 import { useToast } from 'primevue/usetoast';
@@ -10,6 +11,7 @@ import { buildFetchUrl } from '../utils/helper/helper';
 import { CollectionAccessObject, PaginationData, PaginationResult } from '../models/types';
 import { DataTablePageEvent, DataTableSortEvent } from 'primevue';
 
+const INPUT_DELAY: number = 300;
 const baseFetchUrl: string = '/api/collections';
 
 const toast: ToastServiceMethods = useToast();
@@ -19,11 +21,12 @@ const pagination = ref<PaginationData | null>(null);
 
 // Refs for fetch url params to re-fetch collections on change
 const searchInput = ref<string>('');
+const debouncedSearchInput = refDebounced(searchInput, INPUT_DELAY);
+
 const offset = ref<number>(0);
 // TODO: Make dynamically
 const rowCount = ref<number>(10);
 const sortField = ref<string>('');
-// TODO: Should this be set here or on the server?
 const sortDirection = ref<'asc' | 'desc'>('asc');
 
 const fetchUrl = computed<string>(() => {
@@ -33,7 +36,7 @@ const fetchUrl = computed<string>(() => {
   searchParams.set('order', sortDirection.value);
   searchParams.set('limit', rowCount.value.toString());
   searchParams.set('skip', offset.value.toString());
-  searchParams.set('search', searchInput.value);
+  searchParams.set('search', debouncedSearchInput.value);
 
   return `${baseFetchUrl}?${searchParams.toString()}`;
 });

--- a/client/src/views/Overview.vue
+++ b/client/src/views/Overview.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted, watch, computed } from 'vue';
 import Toast from 'primevue/toast';
 import { ToastServiceMethods } from 'primevue/toastservice';
 import { useToast } from 'primevue/usetoast';
@@ -26,9 +26,7 @@ const sortField = ref<string>('');
 // TODO: Should this be set here or on the server?
 const sortDirection = ref<'asc' | 'desc'>('asc');
 
-const fetchUrl = ref<string>(baseFetchUrl);
-
-watch([sortField, sortDirection, rowCount, offset, searchInput], async () => {
+const fetchUrl = computed<string>(() => {
   const searchParams: URLSearchParams = new URLSearchParams();
 
   searchParams.set('sort', sortField.value);
@@ -37,21 +35,12 @@ watch([sortField, sortDirection, rowCount, offset, searchInput], async () => {
   searchParams.set('skip', offset.value.toString());
   searchParams.set('search', searchInput.value);
 
-  fetchUrl.value = baseFetchUrl + '?' + searchParams.toString();
-
-  await getCollections();
+  return `${baseFetchUrl}?${searchParams.toString()}`;
 });
 
+watch(fetchUrl, async () => await getCollections());
+
 onMounted(async (): Promise<void> => {
-  const searchParams: URLSearchParams = new URLSearchParams();
-
-  searchParams.set('sort', sortField.value);
-  searchParams.set('order', sortDirection.value);
-  searchParams.set('limit', rowCount.value.toString());
-  searchParams.set('skip', offset.value.toString());
-  searchParams.set('search', searchInput.value);
-
-  fetchUrl.value = baseFetchUrl + '?' + searchParams.toString();
   await getCollections();
 });
 
@@ -122,7 +111,7 @@ function showMessage(operation: 'created' | 'deleted', detail?: string): void {
 
     <div class="counter text-right pt-2 pb-3">
       <strong class="text-base"
-        >{{ collections ? collections.length : 0 }} Collections in total</strong
+        >{{ pagination ? pagination.totalRecords : 0 }} Collections in total</strong
       >
     </div>
 

--- a/client/src/views/Overview.vue
+++ b/client/src/views/Overview.vue
@@ -21,7 +21,7 @@ const pagination = ref<PaginationData | null>(null);
 const searchInput = ref<string>('');
 const offset = ref<number>(0);
 // TODO: Make dynamically
-const rowCount = ref<number>(5);
+const rowCount = ref<number>(10);
 const sortField = ref<string>('');
 // TODO: Should this be set here or on the server?
 const sortDirection = ref<'asc' | 'desc'>('asc');
@@ -40,9 +40,7 @@ const fetchUrl = computed<string>(() => {
 
 watch(fetchUrl, async () => await getCollections());
 
-onMounted(async (): Promise<void> => {
-  await getCollections();
-});
+onMounted(async (): Promise<void> => await getCollections());
 
 async function getCollections(): Promise<void> {
   try {

--- a/client/src/views/Overview.vue
+++ b/client/src/views/Overview.vue
@@ -20,9 +20,10 @@ const collections = ref<CollectionAccessObject[] | null>(null);
 const pagination = ref<PaginationData | null>(null);
 
 // Refs for fetch url params to re-fetch collections on change
-const searchInput = ref<string>('');
-const debouncedSearchInput = refDebounced(searchInput, INPUT_DELAY);
 
+const searchInput = ref<string>('');
+// This ref is used to prevent too many fetches when rapid typing
+const debouncedSearchInput = refDebounced(searchInput, INPUT_DELAY);
 const offset = ref<number>(0);
 // TODO: Make dynamically
 const rowCount = ref<number>(10);

--- a/client/src/views/Overview.vue
+++ b/client/src/views/Overview.vue
@@ -42,8 +42,11 @@ watch(fetchUrl, async () => await getCollections());
 
 onMounted(async (): Promise<void> => await getCollections());
 
+const asyncOperationRunning = ref<boolean>(false);
+
 async function getCollections(): Promise<void> {
   try {
+    asyncOperationRunning.value = true;
     const url: string = buildFetchUrl(fetchUrl.value);
 
     const response: Response = await fetch(url);
@@ -58,6 +61,8 @@ async function getCollections(): Promise<void> {
     pagination.value = paginationResult.pagination;
   } catch (error: unknown) {
     console.error('Error fetching collections:', error);
+  } finally {
+    asyncOperationRunning.value = false;
   }
 }
 
@@ -118,6 +123,7 @@ function showMessage(operation: 'created' | 'deleted', detail?: string): void {
       @pagination-changed="handlePaginationChange"
       :collections="collections"
       :pagination="pagination"
+      :async-operation-running="asyncOperationRunning"
     />
   </div>
 </template>

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -104,6 +104,20 @@ export type MalformedAnnotation = {
   data: StandoffAnnotation;
 };
 
+export type PaginationData = {
+  limit: number;
+  order: string;
+  search: string;
+  skip: number;
+  sort: string;
+  totalRecords: number;
+};
+
+export type PaginationResult<T> = {
+  data: T;
+  pagination: PaginationData;
+};
+
 export type StandoffAnnotation = {
   [key: string]: string | number | boolean;
   start: number;

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -5,7 +5,12 @@ import CollectionService from '../services/collection.service.js';
 import GuidelinesService from '../services/guidelines.service.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
-import { Collection, CollectionAccessObject, CollectionPostData } from '../models/types.js';
+import {
+  Collection,
+  CollectionAccessObject,
+  CollectionPostData,
+  PaginationResult,
+} from '../models/types.js';
 import { getPagination } from '../utils/helper.js';
 
 const router: Router = express.Router({ mergeParams: true });
@@ -26,7 +31,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
 
     const { sort, order, limit, skip, search } = getPagination(req);
 
-    const collections: CollectionAccessObject[] =
+    const collections: PaginationResult<CollectionAccessObject[]> =
       await collectionService.getCollectionsWithTextsAndParams(
         primaryCollectionLabel,
         sort,

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -32,7 +32,7 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
     const { sort, order, limit, skip, search } = getPagination(req);
 
     const collections: PaginationResult<CollectionAccessObject[]> =
-      await collectionService.getCollectionsWithTextsAndParams(
+      await collectionService.getCollections(
         primaryCollectionLabel,
         sort,
         order,

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -6,6 +6,7 @@ import GuidelinesService from '../services/guidelines.service.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
 import { Collection, CollectionAccessObject, CollectionPostData } from '../models/types.js';
+import { getPagination } from '../utils/helper.js';
 
 const router: Router = express.Router({ mergeParams: true });
 
@@ -23,8 +24,17 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
       t => t.level === 'primary',
     )!.additionalLabel;
 
+    const { sort, order, limit, skip, search } = getPagination(req);
+
     const collections: CollectionAccessObject[] =
-      await collectionService.getCollectionsWithTexts(primaryCollectionLabel);
+      await collectionService.getCollectionsWithTextsAndParams(
+        primaryCollectionLabel,
+        sort,
+        order,
+        limit,
+        skip,
+        search,
+      );
 
     res.status(200).json(collections);
   } catch (error: unknown) {

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -72,6 +72,18 @@ export default class CollectionService {
     return result.records[0]?.get('collections');
   }
 
+  /**
+   * Retrieves paginated collection nodes together with connected text nodes. Additional node labels for the collection node
+   * as well as pagination parameters are provided.
+   *
+   * @param {string} additionalLabel - The additional label to match in the query, e.g., "Letter".
+   * @param {string} sort - The field by which to sort the collections.
+   * @param {string} order - The order in which to sort the collections (ascending or descending).
+   * @param {number} limit - The maximum number of collections to return.
+   * @param {number} skip - The number of collections to skip before starting to collect the result set.
+   * @param {string} search - The search string to filter collections by their label.
+   * @return {Promise<PaginationResult<CollectionAccessObject[]>>} A promise that resolves to a paginated result of collection access objects.
+   */
   public async getCollectionsWithTextsAndParams(
     additionalLabel: string,
     sort: string,

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -20,59 +20,6 @@ type CollectionTextObject = {
 
 export default class CollectionService {
   /**
-   * Retrieves collection nodes based on the additional label provided.
-   *
-   * @param {string} additionalLabel - The additional label to match in the query, for example "Letter" for collection nodes containing text metadata.
-   * @return {Promise<ICollection[]>} A promise that resolves to an array of collections.
-   */
-  public async getCollections(additionalLabel: string): Promise<ICollection[]> {
-    const query: string = `
-    MATCH (n:Collection:${additionalLabel}) RETURN collect(n {.*}) as collections
-    `;
-
-    const result: QueryResult = await Neo4jDriver.runQuery(query);
-
-    return result.records[0]?.get('collections');
-  }
-
-  /**
-   * Retrieves collection nodes together with connected text nodes based on the additional label provided.
-   *
-   * @param {string} additionalLabel - The additional label to match in the query, for example "Letter" for collection nodes containing text metadata.
-   * @return {Promise<CollectionAccessObject[]>} A promise that resolves to an array of collection access objects.
-   */
-  public async getCollectionsWithTexts(additionalLabel: string): Promise<CollectionAccessObject[]> {
-    const query: string = `
-    MATCH (c:Collection:${additionalLabel})
-
-    // Match optional Text node chain
-    OPTIONAL MATCH (c)<-[:PART_OF]-(tStart:Text)
-    WHERE NOT ()-[:NEXT]->(tStart)
-    OPTIONAL MATCH (tStart)-[:NEXT*]->(t:Text)
-
-    WITH c, tStart, collect(t) AS nextTexts
-    WITH c, coalesce(tStart, []) + nextTexts AS texts
-
-    RETURN collect({
-        collection: {
-            nodeLabels: [l IN labels(c) WHERE l <> 'Collection' | l],
-            data: c {.*}
-        }, 
-        texts: [
-            t IN texts | {
-                nodeLabels: [l IN labels(t) WHERE l <> 'Text' | l],
-                data: t {.*}
-            }
-        ]
-    }) AS collections
-    `;
-
-    const result: QueryResult = await Neo4jDriver.runQuery(query);
-
-    return result.records[0]?.get('collections');
-  }
-
-  /**
    * Retrieves paginated collection nodes together with connected text nodes. Additional node labels for the collection node
    * as well as pagination parameters are provided.
    *
@@ -84,7 +31,7 @@ export default class CollectionService {
    * @param {string} search - The search string to filter collections by their label.
    * @return {Promise<PaginationResult<CollectionAccessObject[]>>} A promise that resolves to a paginated result of collection access objects.
    */
-  public async getCollectionsWithTextsAndParams(
+  public async getCollections(
     additionalLabel: string,
     sort: string,
     order: string,

--- a/server/src/utils/helper.ts
+++ b/server/src/utils/helper.ts
@@ -1,3 +1,5 @@
+import { Request } from 'express';
+
 /**
  * Capitalizes the first letter of a given string.
  *
@@ -6,4 +8,48 @@
  */
 export function capitalize(inputString: string): string {
   return inputString.charAt(0).toUpperCase() + inputString.slice(1);
+}
+
+// Valid Order directions
+const ORDER_ASC: string = 'ASC';
+const ORDER_DESC: string = 'DESC';
+const ORDERS: string[] = [ORDER_ASC, ORDER_DESC];
+
+// export const MOVIE_SORT: string[] = ['title', 'released', 'imdbRating'];
+// export const PEOPLE_SORT: string[] = ['name', 'born', 'movieCount'];
+// export const RATING_SORT: string[] = ['rating', 'timestamp'];
+
+/**
+ * Extract commonly used pagination variables from the request query string.
+ *
+ * Copied from the official Neo4j Graphacademy repo: https://github.com/neo4j-graphacademy/app-nodejs/blob/main/src/routes/movies.routes.js
+ *
+ * @param {Request} req - The request object.
+ * @returns {Record<string, any>}
+ */
+export function getPagination(req: Request): Record<string, any> {
+  let { search, limit, skip, sort, order } = req.query;
+
+  // Only accept valid orderby fields
+  if (!sort) {
+    // TODO: Move to constant?
+    sort = 'label';
+  }
+
+  if (!search) {
+    search = '';
+  }
+
+  // Only accept ASC/DESC values
+  if (order === undefined || !ORDERS.includes(order.toString().toUpperCase())) {
+    order = ORDER_ASC;
+  }
+
+  return {
+    search,
+    sort,
+    order,
+    limit: parseInt(limit as string) || 100,
+    skip: parseInt(skip as string) || 0,
+  };
 }

--- a/server/src/utils/helper.ts
+++ b/server/src/utils/helper.ts
@@ -28,6 +28,8 @@ const ORDERS: string[] = [ORDER_ASC, ORDER_DESC];
  * @returns {Record<string, any>}
  */
 export function getPagination(req: Request): Record<string, any> {
+  // TODO: Fix types
+  // TODO: Fix JSDoc
   let { search, limit, skip, sort, order } = req.query;
 
   // Only accept valid orderby fields

--- a/server/src/utils/helper.ts
+++ b/server/src/utils/helper.ts
@@ -10,40 +10,35 @@ export function capitalize(inputString: string): string {
   return inputString.charAt(0).toUpperCase() + inputString.slice(1);
 }
 
-// Valid Order directions
-const ORDER_ASC: string = 'ASC';
-const ORDER_DESC: string = 'DESC';
-const ORDERS: string[] = [ORDER_ASC, ORDER_DESC];
-
-// export const MOVIE_SORT: string[] = ['title', 'released', 'imdbRating'];
-// export const PEOPLE_SORT: string[] = ['name', 'born', 'movieCount'];
-// export const RATING_SORT: string[] = ['rating', 'timestamp'];
-
 /**
- * Extract commonly used pagination variables from the request query string.
+ * Parses pagination parameters from the request query.
  *
- * Copied from the official Neo4j Graphacademy repo: https://github.com/neo4j-graphacademy/app-nodejs/blob/main/src/routes/movies.routes.js
+ * Copied from the official Neo4j Graphacademy repo: https://github.com/neo4j-graphacademy/app-nodejs/blob/main/src/utils.js
+ * and modiefied.
  *
- * @param {Request} req - The request object.
- * @returns {Record<string, any>}
+ * @param {Request} req - The express request object.
+ * @returns {Record<string, any>} An object with the following properties:
+ *   - `search`: The search string to filter by.
+ *   - `sort`: The field to sort by.
+ *   - `order`: The direction of the sort (ascending/descending).
+ *   - `limit`: The maximum number of results to return.
+ *   - `skip`: The number of results to skip.
  */
 export function getPagination(req: Request): Record<string, any> {
-  // TODO: Fix types
-  // TODO: Fix JSDoc
+  // TODO: Should this function have more restriction functionalities/error handling
   let { search, limit, skip, sort, order } = req.query;
 
-  // Only accept valid orderby fields
-  if (!sort) {
-    // TODO: Move to constant?
-    sort = 'label';
-  }
+  // Valid Order directions
+  const ORDER_ASC: string = 'ASC';
+  const ORDER_DESC: string = 'DESC';
+  const ORDERS: string[] = [ORDER_ASC, ORDER_DESC];
 
-  if (!search) {
-    search = '';
-  }
+  // Set default values
+  sort ||= 'label';
+  search ||= '';
 
   // Only accept ASC/DESC values
-  if (order === undefined || !ORDERS.includes(order.toString().toUpperCase())) {
+  if (!order || !ORDERS.includes(order.toString().toUpperCase())) {
     order = ORDER_ASC;
   }
 


### PR DESCRIPTION
Collection nodes are now paginated/filtered/sorted in the backend instead of sending all data to the frontend and paginate/filter/sort there. Better for performance with larger numbers of Collection nodes.

Key changes:

- Pagination parameters are included in cypher queries in collection service.
- Helper method for parsing pagination parameters from requests was added.
- Changes in input search field are applied after timeout to prevent request overload.
- Sorting functionality in collection table is restricted to Collection node properties (and removed from text count and node labels)

The last bullet point is because of the different nature of the table data: Some are node properties, some are node labels, and some are the number of connected nodes. Therefore, the database queries will have to vary a lot to cover all cases. This will be re-implemented in the future when the handling for all possible data/node types is fixed.