### PR TITLE
Allow Annotations for Collections

### DIFF
--- a/client/src/components/AnnotationFormAdditionalTextSection.vue
+++ b/client/src/components/AnnotationFormAdditionalTextSection.vue
@@ -29,6 +29,7 @@ const additionalTexts = defineModel<AdditionalText[]>();
 
 const props = defineProps<{
   initialAdditionalTexts: AdditionalText[];
+  mode?: 'edit' | 'view';
 }>();
 
 const { guidelines, getCollectionConfigFields } = useGuidelinesStore();
@@ -214,6 +215,7 @@ function toggleAdditionalTextPreviewMode(uuid: string): void {
           }}</span>
           <span v-else class="font-italic"> No label provided yet... </span>
           <Button
+            v-if="props.mode === 'edit'"
             icon="pi pi-times"
             severity="danger"
             title="Remove this text from annotation"
@@ -267,7 +269,9 @@ function toggleAdditionalTextPreviewMode(uuid: string): void {
     </template>
     <div>
       <!-- TODO: the next button was disabled when annotation was truncated. Why? -> Find out... -->
+
       <Button
+        v-if="props.mode === 'edit'"
         v-show="additionalTextInputObject.mode === 'view'"
         class="mt-2 w-full h-2rem"
         icon="pi pi-plus"

--- a/client/src/components/AnnotationFormAdditionalTextSection.vue
+++ b/client/src/components/AnnotationFormAdditionalTextSection.vue
@@ -268,8 +268,6 @@ function toggleAdditionalTextPreviewMode(uuid: string): void {
       <hr />
     </template>
     <div>
-      <!-- TODO: the next button was disabled when annotation was truncated. Why? -> Find out... -->
-
       <Button
         v-if="props.mode === 'edit'"
         v-show="additionalTextInputObject.mode === 'view'"

--- a/client/src/components/AnnotationFormAdditionalTextSection.vue
+++ b/client/src/components/AnnotationFormAdditionalTextSection.vue
@@ -1,0 +1,355 @@
+<script setup lang="ts">
+import { nextTick, Ref, ref, watch } from 'vue';
+import { templateRef } from '@vueuse/core';
+import { useGuidelinesStore } from '../store/guidelines';
+import { camelCaseToTitleCase, getDefaultValueForProperty } from '../utils/helper/helper';
+import Button from 'primevue/button';
+import InputText from 'primevue/inputtext';
+import Fieldset from 'primevue/fieldset';
+import Message from 'primevue/message';
+import { MultiSelect } from 'primevue';
+import Tag from 'primevue/tag';
+import { AdditionalText, PropertyConfig } from '../models/types';
+import InputGroup from 'primevue/inputgroup';
+import ICollection from '../models/ICollection';
+import IText from '../models/IText';
+
+/**
+ * Interface for relevant state information about additional texts of the annotation
+ */
+interface AdditionalTextInputObject {
+  availableLabels: string[];
+  inputElm: Ref<any>;
+  inputLabels: string[];
+  inputText: string;
+  mode: 'edit' | 'view';
+}
+
+const additionalTexts = defineModel<AdditionalText[]>();
+
+const props = defineProps<{
+  initialAdditionalTexts: AdditionalText[];
+}>();
+
+const { guidelines, getCollectionConfigFields } = useGuidelinesStore();
+
+const additionalTextIsCollapsed = ref<boolean>(false);
+const additionalTextInputObject = ref<AdditionalTextInputObject>({
+  inputText: '',
+  availableLabels: guidelines.value.annotations.additionalTexts,
+  inputLabels: [],
+  mode: 'view',
+  inputElm: templateRef('additional-text-input'),
+});
+
+// Used for toggling additional text preview mode. Bit hacky for now, but works.
+const additionalTextStatusObject = ref<Map<string, 'collapsed' | 'expanded'>>(new Map());
+
+watch(
+  () => additionalTexts,
+  (newTexts, oldTexts) => {
+    // Add new text if it doesn't already exist
+    newTexts.value.forEach(text => {
+      if (!additionalTextStatusObject.value.has(text.collection.data.uuid)) {
+        additionalTextStatusObject.value.set(text.collection.data.uuid, 'collapsed');
+      }
+    });
+
+    // Remove texts that no longer exist
+    if (oldTexts) {
+      oldTexts.value.forEach(text => {
+        if (
+          !newTexts.value.some(
+            newText => newText.collection.data.uuid === text.collection.data.uuid,
+          )
+        ) {
+          additionalTextStatusObject.value.delete(text.collection.data.uuid);
+        }
+      });
+    }
+  },
+  { deep: true, immediate: true },
+);
+
+// TODO: Add JSDoc
+function addAdditionalText(): void {
+  const nodeLabels: string[] = additionalTextInputObject.value.inputLabels;
+  const defaultFields: PropertyConfig[] = getCollectionConfigFields(nodeLabels);
+  const newCollectionProperties: ICollection = {} as ICollection;
+
+  defaultFields.forEach((field: PropertyConfig) => {
+    newCollectionProperties[field.name] =
+      field?.required === true ? getDefaultValueForProperty(field.type) : null;
+  });
+
+  additionalTexts.value.push({
+    collection: {
+      nodeLabels,
+      data: {
+        ...newCollectionProperties,
+        uuid: crypto.randomUUID(),
+        // TODO: Fix this.....
+        label: `${nodeLabels.join(' | ')} for annotation this beautiful annotation`,
+      } as ICollection,
+    },
+    text: {
+      // TODO: Text node labels should be made selectable too in the future
+      nodeLabels: [],
+      data: {
+        uuid: crypto.randomUUID(),
+        text: additionalTextInputObject.value.inputText,
+      } as IText,
+    },
+  });
+
+  finishAdditionalTextInputOperation();
+}
+
+/**
+ * Cancels an additional text input operation without submitting any data. This resets the form and
+ * changes the mode to 'view'. Is called when the cancel button is clicked explicitly by the user.
+ *
+ * @returns {void} This function does not return any value.
+ */
+function cancelAdditionalTextOperation(): void {
+  finishAdditionalTextInputOperation();
+}
+
+/**
+ * Changes the mode of the additional text input component between `view` and `edit`. If set to `edit`,
+ * the input field will be focused.
+ *
+ * @param {'view' | 'edit'} mode - The new mode. Is either 'view' or 'edit'.
+ * @returns {void} This function does not return any value.
+ */
+function changeAdditionalTextSelectionMode(mode: 'view' | 'edit'): void {
+  additionalTextInputObject.value.mode = mode;
+
+  if (mode === 'view') {
+    return;
+  }
+
+  // // Wait for DOM to update before trying to focus the element
+  nextTick(() => {
+    // TODO: A bit hacky, replace this when upgraded to Vue 3.5?
+    const inputElm: HTMLInputElement | null = additionalTextInputObject.value.inputElm.$el;
+
+    if (!inputElm) {
+      console.warn('Focus failed: Element not found');
+      return;
+    }
+
+    inputElm.focus();
+  });
+}
+
+/**
+ * Finishes an additional text input operation one way or another (submit or cancel).
+ * This resets the form and changes the mode to 'view'.
+ *
+ * @returns {void} This function does not return any value.
+ */
+function finishAdditionalTextInputOperation(): void {
+  resetAdditionalTextInputForm();
+  changeAdditionalTextSelectionMode('view');
+}
+
+/**
+ * Deletes an additional text entry from the list of additional texts of the annotation.
+ *
+ * @param {string} collectionUuid - The UUID of the collection of the additional text to be deleted.
+ * @returns {void} This function does not return any value.
+ */
+function handleDeleteAdditionalText(collectionUuid: string): void {
+  additionalTexts.value = additionalTexts.value.filter(
+    t => t.collection.data.uuid !== collectionUuid,
+  );
+}
+
+/**
+ * Resets the additional text input form (select input and text input). This prepares the form for new input.
+ * Called when the form is submitted or cancelled.
+ *
+ * @returns {void} This function does not return any value.
+ */
+function resetAdditionalTextInputForm(): void {
+  additionalTextInputObject.value.inputLabels = [];
+  additionalTextInputObject.value.inputText = '';
+}
+
+/**
+ * Toggles the view modeof an additional text entry. By default, the whole text is shown as preview to keep
+ * the form compact, but can be expanded on button click.
+ *
+ * @param {string} uuid - The UUID of the additional text for which the mode should be toggled.
+ */
+function toggleAdditionalTextPreviewMode(uuid: string): void {
+  const currentViewMode: 'collapsed' | 'expanded' = additionalTextStatusObject.value.get(uuid);
+  additionalTextStatusObject.value.set(
+    uuid,
+    currentViewMode === 'collapsed' ? 'expanded' : 'collapsed',
+  );
+}
+</script>
+
+<template>
+  <Fieldset
+    legend="Additional texts"
+    :toggle-button-props="{
+      title: `${additionalTextIsCollapsed ? 'Expand' : 'Collapse'} additional texts`,
+    }"
+    :toggleable="true"
+    @toggle="additionalTextIsCollapsed = !additionalTextIsCollapsed"
+  >
+    <template #toggleicon>
+      <span :class="`pi pi-chevron-${additionalTextIsCollapsed ? 'down' : 'up'}`"></span>
+    </template>
+    <template v-for="additionalText in additionalTexts" :key="additionalText.collection.data.uuid">
+      <div class="additional-text-entry">
+        <div class="additional-text-header flex justify-content-between align-items-center">
+          <span v-if="additionalText.collection.nodeLabels.length > 0" class="font-semibold">{{
+            additionalText.collection.nodeLabels
+              .map((l: string) => camelCaseToTitleCase(l))
+              .join(' | ')
+          }}</span>
+          <span v-else class="font-italic"> No label provided yet... </span>
+          <Button
+            icon="pi pi-times"
+            severity="danger"
+            title="Remove this text from annotation"
+            @click="handleDeleteAdditionalText(additionalText.collection.data.uuid)"
+          />
+        </div>
+        <div class="flex align-items-center gap-2 overflow">
+          <a
+            :href="`/texts/${additionalText.text.data.uuid}`"
+            title="Open text in new editor tab"
+            class="flex align-items-center gap-1"
+            target="_blank"
+          >
+            <div
+              :class="`preview ${additionalTextStatusObject.get(additionalText.collection.data.uuid)}`"
+            >
+              {{ additionalText.text.data.text }}
+            </div>
+            <i class="pi pi-external-link"></i>
+          </a>
+        </div>
+        <Button
+          :icon="
+            additionalTextStatusObject.get(additionalText.collection.data.uuid) === 'collapsed'
+              ? 'pi pi-angle-double-down'
+              : 'pi pi-angle-double-up'
+          "
+          severity="secondary"
+          size="small"
+          class="w-full"
+          :title="
+            additionalTextStatusObject.get(additionalText.collection.data.uuid) === 'collapsed'
+              ? 'Show full text'
+              : 'Hide full text'
+          "
+          @click="toggleAdditionalTextPreviewMode(additionalText.collection.data.uuid)"
+        />
+        <Message
+          v-if="
+            !props.initialAdditionalTexts
+              .map(t => t.collection.data.uuid)
+              .includes(additionalText.collection.data.uuid)
+          "
+          severity="warn"
+        >
+          Save changes to edit new text...
+        </Message>
+      </div>
+
+      <hr />
+    </template>
+    <div>
+      <!-- TODO: the next button was disabled when annotation was truncated. Why? -> Find out... -->
+      <Button
+        v-show="additionalTextInputObject.mode === 'view'"
+        class="mt-2 w-full h-2rem"
+        icon="pi pi-plus"
+        size="small"
+        severity="secondary"
+        label="Add text"
+        title="Add new additional text entry"
+        @click="changeAdditionalTextSelectionMode('edit')"
+      />
+      <form v-show="additionalTextInputObject.mode === 'edit'" @submit.prevent="addAdditionalText">
+        <InputGroup>
+          <MultiSelect
+            v-model="additionalTextInputObject.inputLabels"
+            :options="additionalTextInputObject.availableLabels"
+            display="chip"
+            placeholder="Select collection labels"
+            class="text-center"
+            :filter="false"
+          >
+            <template #chip="{ value }">
+              <Tag :value="value" severity="contrast" class="mr-1" />
+            </template>
+          </MultiSelect>
+          <InputText
+            ref="additional-text-input"
+            required
+            v-model="additionalTextInputObject.inputText"
+            placeholder="Enter text"
+            title="Enter text"
+          />
+          <Button
+            type="submit"
+            icon="pi pi-check"
+            severity="secondary"
+            size="small"
+            title="Add new text"
+          />
+          <Button
+            type="button"
+            icon="pi pi-times"
+            severity="secondary"
+            size="small"
+            title="Cancel"
+            @click="cancelAdditionalTextOperation"
+          />
+        </InputGroup>
+      </form>
+    </div>
+  </Fieldset>
+</template>
+
+<style scoped>
+.preview.collapsed {
+  --fade-start: 50%;
+  max-height: 4rem;
+  mask-image: linear-gradient(to bottom, white var(--fade-start), transparent);
+  transition: max-height 500ms;
+}
+
+.preview.expanded {
+  max-height: auto;
+  max-height: calc-size(auto);
+}
+
+.additional-text-header {
+  cursor: default;
+}
+
+.additional-text-entry {
+  border: 1px solid gray;
+  border-radius: 5px;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+
+  & button {
+    width: 1rem;
+    height: 1rem;
+    padding: 10px;
+  }
+}
+
+.hidden {
+  display: none;
+}
+</style>

--- a/client/src/components/AnnotationFormNormdataSection.vue
+++ b/client/src/components/AnnotationFormNormdataSection.vue
@@ -212,7 +212,6 @@ async function searchNormdataOptions(searchString: string, category: string): Pr
           @click="removeNormdataItem(entry as NormdataEntry, category)"
         ></Button>
       </div>
-      <!-- TODO: the next button was disabled when annotation was truncated. Why? -> Find out... -->
       <Button
         v-if="props.mode === 'edit'"
         v-show="normdataSearchObject[category].mode === 'view'"

--- a/client/src/components/AnnotationFormNormdataSection.vue
+++ b/client/src/components/AnnotationFormNormdataSection.vue
@@ -30,6 +30,10 @@ const normdata = defineModel<{
   [index: string]: IEntity[];
 }>();
 
+const props = defineProps<{
+  mode?: 'edit' | 'view';
+}>();
+
 const { guidelines, getAvailableAnnotationResourceConfigs } = useGuidelinesStore();
 
 const normdataCategories: string[] = getAvailableAnnotationResourceConfigs().map(c => c.category);
@@ -201,6 +205,7 @@ async function searchNormdataOptions(searchString: string, category: string): Pr
           {{ entry.label }}
         </span>
         <Button
+          v-if="props.mode === 'edit'"
           icon="pi pi-times"
           size="small"
           severity="danger"
@@ -209,6 +214,7 @@ async function searchNormdataOptions(searchString: string, category: string): Pr
       </div>
       <!-- TODO: the next button was disabled when annotation was truncated. Why? -> Find out... -->
       <Button
+        v-if="props.mode === 'edit'"
         v-show="normdataSearchObject[category].mode === 'view'"
         class="mt-2 w-full h-2rem"
         icon="pi pi-plus"

--- a/client/src/components/AnnotationFormNormdataSection.vue
+++ b/client/src/components/AnnotationFormNormdataSection.vue
@@ -224,6 +224,7 @@ async function searchNormdataOptions(searchString: string, category: string): Pr
         @click="changeNormdataSelectionMode(category, 'edit')"
       />
       <AutoComplete
+        v-if="props.mode === 'edit'"
         v-show="normdataSearchObject[category].mode === 'edit'"
         v-model="normdataSearchObject[category].currentItem"
         dropdown

--- a/client/src/components/AnnotationFormNormdataSection.vue
+++ b/client/src/components/AnnotationFormNormdataSection.vue
@@ -1,0 +1,278 @@
+<script setup lang="ts">
+import { nextTick, Ref, ref } from 'vue';
+import { templateRef } from '@vueuse/core';
+import { useGuidelinesStore } from '../store/guidelines';
+import { buildFetchUrl, camelCaseToTitleCase } from '../utils/helper/helper';
+import AutoComplete from 'primevue/autocomplete';
+import Button from 'primevue/button';
+import Fieldset from 'primevue/fieldset';
+import IEntity from '../models/IEntity';
+
+/**
+ *  Enriches normdata item with an html key that contains the highlighted parts of the node label
+ * */
+type NormdataEntry = IEntity & { html: string };
+
+/**
+ * Interface for relevant state information about each normdata category
+ */
+interface NormdataSearchObject {
+  [key: string]: {
+    fetchedItems: NormdataEntry[] | string[];
+    nodeLabel: string;
+    currentItem: NormdataEntry | null;
+    mode: 'edit' | 'view';
+    elm: Ref<any>;
+  };
+}
+
+const normdata = defineModel<{
+  [index: string]: IEntity[];
+}>();
+
+const { guidelines, getAvailableAnnotationResourceConfigs } = useGuidelinesStore();
+
+const normdataCategories: string[] = getAvailableAnnotationResourceConfigs().map(c => c.category);
+
+const normdataAreCollapsed = ref<boolean>(false);
+const normdataSearchObject = ref<NormdataSearchObject>(
+  normdataCategories.reduce((object: NormdataSearchObject, category) => {
+    object[category] = {
+      nodeLabel: guidelines.value.annotations.resources.find(r => r.category === category)
+        .nodeLabel,
+      fetchedItems: [],
+      currentItem: null,
+      mode: 'view',
+      // TODO: Use useTemplateRef when upgraded to Vue 3.5
+      elm: templateRef(`input-${category}`),
+    };
+
+    return object;
+  }, {}),
+);
+
+/**
+ * Adds a normdata item to the specified category in the annotation's data.
+ *
+ * @param {NormdataEntry} item - The normdata item to be added.
+ */
+function addNormdataItem(item: NormdataEntry, category: string): void {
+  // Omit 'html' property from entry since it was only created for rendering purposes
+  const { html, ...rest } = item;
+  normdata.value[category].push(rest);
+}
+
+/**
+ * Changes the mode of the normdata search component for the given category. This triggers
+ * re-renders in the template.
+ *
+ * - If set to `view`, the search bar will be hidden and its related state variables reset.
+ * - If set to `edit`, the search bar will be shown and and focused.
+ *
+ * @param {string} category - The category for which the mode should be changed.
+ * @param {'view' | 'edit'} mode - The new mode.
+ */
+function changeNormdataSelectionMode(category: string, mode: 'view' | 'edit'): void {
+  normdataSearchObject.value[category].mode = mode;
+
+  if (mode === 'view') {
+    normdataSearchObject.value[category].currentItem = null;
+
+    return;
+  }
+
+  // Wait for DOM to update before trying to focus the element
+  nextTick(() => {
+    // TODO: A bit hacky, replace this when upgraded to Vue 3.5?
+    // The normdataSearchObject's "elm" property is an one-entry-array with the referenced primevue components
+    // that holds the component. Is an array because since the refs are set in a loop in the template
+    const elm = normdataSearchObject.value[category].elm[0];
+
+    if (!elm) {
+      console.warn(`Focus failed: Element not found for category "${category}"`);
+      return;
+    }
+
+    const inputElement: HTMLInputElement = elm.$el?.querySelector('input');
+
+    inputElement?.focus();
+  });
+}
+
+/**
+ * Handles the selection of a normdata item by adding it to the annotation and resetting the search component.
+ *  Called on selection of an item from the autocomplete dropdown pane.
+ *
+ * @param {NormdataEntry} item - The normdata item to be added.
+ * @param {string} category - The category to which the item should be added.
+ */
+function handleNormdataItemSelect(item: NormdataEntry, category: string): void {
+  addNormdataItem(item, category);
+  changeNormdataSelectionMode(category, 'view');
+}
+
+/**
+ * Removes a normdata item from the given category in the annotation's data.
+ *
+ * @param {NormdataEntry} item - The normdata item to be removed.
+ * @param {string} category - The category from which the item should be removed.
+ */
+function removeNormdataItem(item: NormdataEntry, category: string): void {
+  normdata.value[category] = normdata.value[category].filter(entry => entry.uuid !== item.uuid);
+}
+
+/**
+ * Replaces all occurrences of a search string in a given text with a highlighted HTML
+ * equivalent. If the search string is empty, the original text is returned.
+ *
+ * @param {string} text - The text in which the search string should be found.
+ * @param {string} searchStr - The string to be searched for.
+ *
+ * @returns {string} The text with all occurrences of the search string highlighted.
+ */
+function renderHTML(text: string, searchStr: string): string {
+  if (searchStr !== '') {
+    const regex: RegExp = new RegExp(`(${searchStr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi');
+
+    return text.replace(regex, '<span style="background-color: yellow">$1</span>');
+  }
+
+  return text;
+}
+
+/**
+ * Fetches normdata items from the server whose's label matches the given search string and stores the results
+ * in the corresponding normdataSearchObject entry.
+ *
+ * @param {string} searchString - The string to be searched for.
+ * @param {string} category - The category for which the search should be performed.
+ */
+async function searchNormdataOptions(searchString: string, category: string): Promise<void> {
+  const nodeLabel: string = normdataSearchObject.value[category].nodeLabel;
+  const url: string = buildFetchUrl(`/api/resources?node=${nodeLabel}&searchStr=${searchString}`);
+
+  const response: Response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error('Network response was not ok');
+  }
+
+  const fetchedNormdata: NormdataEntry[] = await response.json();
+
+  // Show only entries that are not already part of the annotation
+  const existingUuids: string[] = normdata.value[category].map(
+    (entry: NormdataEntry) => entry.uuid,
+  );
+
+  const withoutDuplicates: NormdataEntry[] = fetchedNormdata.filter(
+    (entry: NormdataEntry) => !existingUuids.includes(entry.uuid),
+  );
+
+  // Store HTML directly in prop to prevent unnecessary, primevue-enforced re-renders during hover
+  const withHtml = withoutDuplicates.map((entry: NormdataEntry) => ({
+    ...entry,
+    html: renderHTML(entry.label, searchString),
+  }));
+
+  normdataSearchObject.value[category].fetchedItems = withHtml;
+}
+</script>
+
+<template>
+  <Fieldset
+    legend="Normdata"
+    :toggleable="true"
+    :toggle-button-props="{
+      title: `${normdataAreCollapsed ? 'Expand' : 'Collapse'} normdata`,
+    }"
+    @toggle="normdataAreCollapsed = !normdataAreCollapsed"
+  >
+    <template #toggleicon>
+      <span :class="`pi pi-chevron-${normdataAreCollapsed ? 'down' : 'up'}`"></span>
+    </template>
+
+    <div v-for="category in normdataCategories">
+      <p class="font-bold">{{ camelCaseToTitleCase(category) }}:</p>
+      <div
+        class="normdata-entry flex justify-content-between align-items-center"
+        v-for="entry in normdata[category]"
+      >
+        <span>
+          {{ entry.label }}
+        </span>
+        <Button
+          icon="pi pi-times"
+          size="small"
+          severity="danger"
+          @click="removeNormdataItem(entry as NormdataEntry, category)"
+        ></Button>
+      </div>
+      <!-- TODO: the next button was disabled when annotation was truncated. Why? -> Find out... -->
+      <Button
+        v-show="normdataSearchObject[category].mode === 'view'"
+        class="mt-2 w-full h-2rem"
+        icon="pi pi-plus"
+        size="small"
+        severity="secondary"
+        label="Add item"
+        @click="changeNormdataSelectionMode(category, 'edit')"
+      />
+      <AutoComplete
+        v-show="normdataSearchObject[category].mode === 'edit'"
+        v-model="normdataSearchObject[category].currentItem"
+        dropdown
+        dropdownMode="current"
+        :placeholder="`Type to see suggestions`"
+        :suggestions="normdataSearchObject[category].fetchedItems"
+        :overlayClass="normdataSearchObject[category].mode === 'view' ? 'hidden' : ''"
+        optionLabel="label"
+        class="mt-2 w-full h-2rem"
+        variant="filled"
+        :ref="`input-${category}`"
+        input-class="w-full"
+        @complete="searchNormdataOptions($event.query, category)"
+        @option-select="handleNormdataItemSelect($event.value, category)"
+      >
+        <template #header v-if="normdataSearchObject[category].fetchedItems.length > 0">
+          <div class="font-medium px-3 py-2">
+            {{ normdataSearchObject[category].fetchedItems.length }} Results
+          </div>
+        </template>
+        <template #option="slotProps">
+          <span v-html="slotProps.option.html" :title="slotProps.option.label"></span>
+        </template>
+      </AutoComplete>
+    </div>
+  </Fieldset>
+</template>
+
+<style scoped>
+.preview.collapsed {
+  --fade-start: 50%;
+  max-height: 4rem;
+  mask-image: linear-gradient(to bottom, white var(--fade-start), transparent);
+  transition: max-height 500ms;
+}
+
+.preview.expanded {
+  max-height: auto;
+  max-height: calc-size(auto);
+}
+
+.normdata-entry {
+  border: 1px solid gray;
+  border-radius: 5px;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+
+  & button {
+    width: 1rem;
+    height: 1rem;
+    padding: 10px;
+  }
+}
+
+.hidden {
+  display: none;
+}
+</style>

--- a/client/src/components/CollectionAnnotationButton.vue
+++ b/client/src/components/CollectionAnnotationButton.vue
@@ -147,12 +147,14 @@ function createNewAnnotation(type: string, subtype: string | number | undefined)
       field?.required === true ? getDefaultValueForProperty(field.type) : null;
   });
 
+  // TODO: This should come from the guidelines. When annotations
+  // are generic, do this
   // Other fields (can only be set during save (indizes), must be set explicitly (uuid, text) etc.)
   newAnnotationData.type = type;
-  newAnnotationData.startIndex = 0;
-  newAnnotationData.endIndex = 0;
+  // newAnnotationData.startIndex = 0;
+  // newAnnotationData.endIndex = 0;
   // TODO: the text property is different...
-  newAnnotationData.text = '';
+  // newAnnotationData.text = '';
   newAnnotationData.uuid = crypto.randomUUID();
 
   // If a subtype field exists (filled with a default value just before), but not subtype was provided

--- a/client/src/components/CollectionAnnotationButton.vue
+++ b/client/src/components/CollectionAnnotationButton.vue
@@ -2,7 +2,6 @@
 import AnnotationTypeIcon from './AnnotationTypeIcon.vue';
 import { cloneDeep, getDefaultValueForProperty } from '../utils/helper/helper';
 import { useGuidelinesStore } from '../store/guidelines';
-import { useFilterStore } from '../store/filter';
 // import { useHistoryStore } from '../store/history';
 import { useShortcutsStore } from '../store/shortcuts';
 import { useToast } from 'primevue/usetoast';
@@ -15,9 +14,10 @@ import { ToastServiceMethods } from 'primevue/toastservice';
 import ShortcutError from '../utils/errors/shortcut.error';
 import { onMounted, ref } from 'vue';
 
-const { annotationType, collectionNodeLabels } = defineProps<{
+const { annotationType, collectionNodeLabels, mode } = defineProps<{
   annotationType: string;
   collectionNodeLabels: string[];
+  mode: 'edit' | 'view';
 }>();
 
 const emit = defineEmits(['addAnnotation']);
@@ -189,6 +189,7 @@ function createNewAnnotation(type: string, subtype: string | number | undefined)
     :style="{ height: '35px', width: '35px' }"
     :class="hasIcon ? '' : 'button-empty'"
     :data-annotation-type="annotationType"
+    :disabled="mode === 'view'"
     v-tooltip.hover.top="{ value: annotationType, showDelay: 50 }"
     @click="handleButtonClick"
   >

--- a/client/src/components/CollectionAnnotationButton.vue
+++ b/client/src/components/CollectionAnnotationButton.vue
@@ -1,0 +1,228 @@
+<script setup lang="ts">
+import AnnotationTypeIcon from './AnnotationTypeIcon.vue';
+import { cloneDeep, getDefaultValueForProperty } from '../utils/helper/helper';
+import { useGuidelinesStore } from '../store/guidelines';
+import { useFilterStore } from '../store/filter';
+// import { useHistoryStore } from '../store/history';
+import { useShortcutsStore } from '../store/shortcuts';
+import { useToast } from 'primevue/usetoast';
+import AnnotationRangeError from '../utils/errors/annotationRange.error';
+import { AdditionalText, PropertyConfig, AnnotationType, AnnotationData } from '../models/types';
+import IAnnotation from '../models/IAnnotation';
+import Button from 'primevue/button';
+import SplitButton from 'primevue/splitbutton';
+import { ToastServiceMethods } from 'primevue/toastservice';
+import ShortcutError from '../utils/errors/shortcut.error';
+import { onMounted, ref } from 'vue';
+
+const { annotationType, collectionNodeLabels } = defineProps<{
+  annotationType: string;
+  collectionNodeLabels: string[];
+}>();
+
+const emit = defineEmits(['addAnnotation']);
+
+const { guidelines, getCollectionAnnotationFields, getCollectionAnnotationConfig } =
+  useGuidelinesStore();
+const { normalizeKeys, registerShortcut } = useShortcutsStore();
+// const { pushHistoryEntry } = useHistoryStore();
+const toast: ToastServiceMethods = useToast();
+
+const config: AnnotationType = getCollectionAnnotationConfig(collectionNodeLabels, annotationType);
+const fields: PropertyConfig[] = getCollectionAnnotationFields(
+  collectionNodeLabels,
+  annotationType,
+);
+const subtypeField: PropertyConfig = fields.find(field => field.name === 'subtype');
+const options: string[] | number[] = subtypeField?.options ?? [];
+const dropdownOptions = options.map((option: string | number) => {
+  return {
+    label: option.toString(),
+    command: () => handleDropdownClick(option),
+  };
+});
+
+const hasIcon = ref<boolean>(true);
+const buttonElm = ref(null);
+
+if (config.shortcut?.length > 0) {
+  const shortcutCombo: string = normalizeKeys(config.shortcut?.map(key => key.toLowerCase()) ?? []);
+  registerShortcut(shortcutCombo, handleClick);
+}
+
+// TODO: This is a temporary hack since PrimeVue makes problems with accessing the component's
+// DOM element with the pcButton/pcDropdown pt option...fix maybe later, but works for now
+onMounted(setButtonStylingManually);
+
+function setButtonStylingManually(): void {
+  // This function examines the DOM nodes of the annotation icon span. If the background image could not be loaded
+  // (since it wasn't provided, bad internet connection etc.), the buttons shows the annotation type as string
+  const iconElement: HTMLSpanElement = buttonElm.value.$el.querySelector(
+    `.annotation-type-icon-${annotationType}`,
+  );
+
+  // Return if element was not found
+  if (!iconElement) {
+    return;
+  }
+
+  // If no background image, set hasIcon to false. This will style normal annotation buttons correctly (see Button props)
+  const hasBackgroundImage: boolean =
+    window.getComputedStyle(iconElement).backgroundImage !== 'none';
+
+  hasIcon.value = hasBackgroundImage;
+
+  // SplitButton has its flaws: Dropdown button and annotation button can not be accessed (wait for Primevue update),
+  // therefore the DOM element need to be queried and styled manually. this is done via the subtypeField variable
+  if (subtypeField) {
+    const dropdownButton: HTMLButtonElement | null =
+      buttonElm.value.$el.querySelector('.p-splitbutton-dropdown');
+    const mainButton: HTMLButtonElement | null =
+      buttonElm.value.$el.querySelector('.p-splitbutton-button');
+
+    if (dropdownButton) {
+      dropdownButton.style.width = '15px';
+    }
+
+    if (mainButton) {
+      mainButton.style.width = '35px';
+      mainButton.style.paddingLeft = '5px';
+      mainButton.style.paddingRight = '5px';
+    }
+
+    // When there is no background image AND the annotation has a SplitButton component, the width is set to 'auto'
+    // with the primeflex utility class 'w-auto'.
+    if (!hasBackgroundImage) {
+      const splitButtonElm: HTMLButtonElement = buttonElm.value.$el.querySelector(
+        'button.p-splitbutton-button',
+      );
+
+      splitButtonElm?.classList.add('w-auto');
+    }
+  }
+}
+
+function handleDropdownClick(subtype: string | number): void {
+  handleClick(subtype);
+}
+
+function handleButtonClick(): void {
+  handleClick();
+}
+
+function handleClick(dropdownOption?: string | number): void {
+  try {
+    const newAnnotation: AnnotationData = createNewAnnotation(annotationType, dropdownOption);
+
+    // TODO: Push to store instead of emitting
+    emit('addAnnotation', newAnnotation);
+    // addAnnotation(newAnnotation);
+  } catch (error) {
+    if (error instanceof AnnotationRangeError) {
+      toast.add({
+        severity: 'warn',
+        summary: 'Invalid selection',
+        detail: error.message,
+        life: 3000,
+      });
+    } else if (error instanceof ShortcutError) {
+      toast.add({
+        severity: 'warn',
+        summary: 'Annotation type not enabled',
+        detail: error.message,
+        life: 3000,
+      });
+    } else {
+      console.error('Unexpected error:', error);
+    }
+  }
+}
+
+function createNewAnnotation(type: string, subtype: string | number | undefined): AnnotationData {
+  const newAnnotationData: IAnnotation = {} as IAnnotation;
+
+  // Base properties
+  fields.forEach((field: PropertyConfig) => {
+    newAnnotationData[field.name] =
+      field?.required === true ? getDefaultValueForProperty(field.type) : null;
+  });
+
+  // Other fields (can only be set during save (indizes), must be set explicitly (uuid, text) etc.)
+  newAnnotationData.type = type;
+  newAnnotationData.startIndex = 0;
+  newAnnotationData.endIndex = 0;
+  // TODO: the text property is different...
+  newAnnotationData.text = '';
+  newAnnotationData.uuid = crypto.randomUUID();
+
+  // If a subtype field exists (filled with a default value just before), but not subtype was provided
+  // (= the user clicked the button directly instead of selecting an entry from the dropdown),
+  // set the first option as default value
+  if (subtypeField) {
+    newAnnotationData.subtype = subtype ?? subtypeField.options[0];
+  }
+
+  // Normdata (= connected Entity nodes). Empty when created, but needed in Annotation structure -> empty arrays
+  const normdataCategories: string[] = guidelines.value.annotations.resources.map(r => r.category);
+  const newAnnotationNormdata = Object.fromEntries(normdataCategories.map(m => [m, []]));
+
+  // Additional texts (= connected Collection->Text nodes). Empty when created, but needed in Annotation structure -> empty arrays
+  const additionalTexts: AdditionalText[] = [];
+
+  const newAnnotation: AnnotationData = {
+    properties: cloneDeep(newAnnotationData),
+    normdata: cloneDeep(newAnnotationNormdata),
+    additionalTexts: cloneDeep(additionalTexts),
+  };
+
+  return newAnnotation;
+}
+</script>
+
+<template>
+  <Button
+    v-if="!subtypeField"
+    severity="secondary"
+    ref="buttonElm"
+    outlined
+    raised
+    :style="{ height: '35px', width: '35px' }"
+    :class="hasIcon ? '' : 'button-empty'"
+    :data-annotation-type="annotationType"
+    v-tooltip.hover.top="{ value: annotationType, showDelay: 50 }"
+    @click="handleButtonClick"
+  >
+    <template #icon>
+      <AnnotationTypeIcon v-if="hasIcon" :annotationType="annotationType" />
+    </template>
+    <template #default>
+      <span v-if="!hasIcon"> {{ annotationType }} </span>
+    </template>
+  </Button>
+  <SplitButton
+    v-else
+    severity="secondary"
+    outlined
+    raised
+    ref="buttonElm"
+    :style="{ height: '35px' }"
+    :class="hasIcon ? '' : 'w-auto'"
+    :model="dropdownOptions"
+    v-tooltip.hover.top="{ value: annotationType, showDelay: 50 }"
+    @click="handleButtonClick"
+  >
+    <template #icon>
+      <AnnotationTypeIcon :annotationType="annotationType" />
+    </template>
+    <template #default>
+      <span v-if="!hasIcon"> {{ annotationType }} </span>
+    </template>
+  </SplitButton>
+</template>
+
+<style scoped>
+.button-empty {
+  padding: 0 5px;
+  width: auto !important;
+}
+</style>

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -142,16 +142,22 @@ function setRangeAnchorAtEnd(): void {
       <template #toggleicon>
         <span :class="`pi pi-chevron-${propertiesAreCollapsed ? 'down' : 'up'}`"></span>
       </template>
-      <FormPropertiesSection v-model="annotation.data.properties" :fields="propertyFields" />
+      <FormPropertiesSection
+        v-model="annotation.data.properties"
+        :fields="propertyFields"
+        mode="edit"
+      />
     </Fieldset>
     <AnnotationFormNormdataSection
       v-if="config.hasNormdata === true"
       v-model="annotation.data.normdata"
+      mode="edit"
     />
     <AnnotationFormAdditionalTextSection
       v-if="config.hasAdditionalTexts === true"
       v-model="annotation.data.additionalTexts"
       :initial-additional-texts="annotation.initialData.additionalTexts"
+      mode="edit"
     />
 
     <div class="edit-buttons flex justify-content-center">

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -1,43 +1,22 @@
 <script setup lang="ts">
-import { nextTick, Ref, ref, watch } from 'vue';
-import { templateRef } from '@vueuse/core';
+import { ref } from 'vue';
 import { useAnnotationStore } from '../store/annotations';
 import { useCharactersStore } from '../store/characters';
 import { useEditorStore } from '../store/editor';
 import { useGuidelinesStore } from '../store/guidelines';
-import {
-  camelCaseToTitleCase,
-  getDefaultValueForProperty,
-  toggleTextHightlighting,
-} from '../utils/helper/helper';
+import { camelCaseToTitleCase, toggleTextHightlighting } from '../utils/helper/helper';
 import Button from 'primevue/button';
 import ConfirmPopup from 'primevue/confirmpopup';
-import InputText from 'primevue/inputtext';
 import Fieldset from 'primevue/fieldset';
-import Message from 'primevue/message';
-import { MultiSelect } from 'primevue';
 import Panel from 'primevue/panel';
 import Tag from 'primevue/tag';
 import { useConfirm } from 'primevue/useconfirm';
 import { Annotation, AnnotationType, PropertyConfig } from '../models/types';
-import InputGroup from 'primevue/inputgroup';
-import ICollection from '../models/ICollection';
-import IText from '../models/IText';
 import AnnotationFormNormdataSection from './AnnotationFormNormdataSection.vue';
+import AnnotationFormAdditionalTextSection from './AnnotationFormAdditionalTextSection.vue';
 import AnnotationTypeIcon from './AnnotationTypeIcon.vue';
 import DataInputComponent from '../components/DataInputComponent.vue';
 import DataInputGroup from '../components/DataInputGroup.vue';
-
-/**
- * Interface for relevant state information about additional texts of the annotation
- */
-interface AdditionalTextInputObject {
-  availableLabels: string[];
-  inputElm: Ref<any>;
-  inputLabels: string[];
-  inputText: string;
-  mode: 'edit' | 'view';
-}
 
 const props = defineProps<{
   annotation: Annotation;
@@ -57,79 +36,12 @@ const {
 } = useAnnotationStore();
 const { removeAnnotationFromCharacters } = useCharactersStore();
 const { newRangeAnchorUuid } = useEditorStore();
-const { guidelines, getAnnotationConfig, getAnnotationFields, getCollectionConfigFields } =
-  useGuidelinesStore();
+const { getAnnotationConfig, getAnnotationFields } = useGuidelinesStore();
 
 const config: AnnotationType = getAnnotationConfig(annotation.data.properties.type);
 const fields: PropertyConfig[] = getAnnotationFields(annotation.data.properties.type);
 
 const propertiesAreCollapsed = ref<boolean>(false);
-const additionalTextIsCollapsed = ref<boolean>(false);
-
-const additionalTextInputObject = ref<AdditionalTextInputObject>({
-  inputText: '',
-  availableLabels: guidelines.value.annotations.additionalTexts,
-  inputLabels: [],
-  mode: 'view',
-  inputElm: templateRef('additional-text-input'),
-});
-
-// Used for toggling additional text preview mode. Bit hacky for now, but works.
-const additionalTextStatusObject = ref<Map<string, 'collapsed' | 'expanded'>>(new Map());
-
-watch(
-  () => annotation.data.additionalTexts,
-  (newTexts, oldTexts) => {
-    // Add new text if it doesn't already exist
-    newTexts.forEach(text => {
-      if (!additionalTextStatusObject.value.has(text.collection.data.uuid)) {
-        additionalTextStatusObject.value.set(text.collection.data.uuid, 'collapsed');
-      }
-    });
-
-    // Remove texts that no longer exist
-    if (oldTexts) {
-      oldTexts.forEach(text => {
-        if (!newTexts.some(newText => newText.collection.data.uuid === text.collection.data.uuid)) {
-          additionalTextStatusObject.value.delete(text.collection.data.uuid);
-        }
-      });
-    }
-  },
-  { deep: true, immediate: true },
-);
-
-function changeAdditionalTextSelectionMode(mode: 'view' | 'edit'): void {
-  additionalTextInputObject.value.mode = mode;
-
-  if (mode === 'view') {
-    return;
-  }
-
-  // // Wait for DOM to update before trying to focus the element
-  nextTick(() => {
-    // TODO: A bit hacky, replace this when upgraded to Vue 3.5?
-    const inputElm: HTMLInputElement | null = additionalTextInputObject.value.inputElm.$el;
-
-    if (!inputElm) {
-      console.warn('Focus failed: Element not found');
-      return;
-    }
-
-    inputElm.focus();
-  });
-}
-
-/**
- * Finishes an additional text input operation one way or another (submit or cancel).
- * This resets the form and changes the mode to 'view'.
- *
- * @returns {void} This function does not return any value.
- */
-function finishAdditionalTextInputOperation(): void {
-  resetAdditionalTextInputForm();
-  changeAdditionalTextSelectionMode('view');
-}
 
 function handleDeleteAnnotation(event: MouseEvent, uuid: string): void {
   confirm.require({
@@ -175,76 +87,9 @@ function handleShrink(): void {
   setRangeAnchorAtEnd();
 }
 
-/**
- * Resets the additional text input form (select input and text input). This prepares the form for new input.
- * Called when the form is submitted or cancelled.
- *
- * @returns {void} This function does not return any value.
- */
-function resetAdditionalTextInputForm(): void {
-  additionalTextInputObject.value.inputLabels = [];
-  additionalTextInputObject.value.inputText = '';
-}
-
 function setRangeAnchorAtEnd(): void {
   const { lastCharacter } = getAnnotationInfo(annotation);
   newRangeAnchorUuid.value = lastCharacter.data.uuid;
-}
-
-/**
- * Toggles the view modeof an additional text entry. By default, the whole text is shown as preview to keep
- * the form compact, but can be expanded on button click.
- *
- * @param {string} uuid - The UUID of the additional text for which the mode should be toggled.
- */
-function toggleAdditionalTextPreviewMode(uuid: string): void {
-  const currentViewMode: 'collapsed' | 'expanded' = additionalTextStatusObject.value.get(uuid);
-  additionalTextStatusObject.value.set(
-    uuid,
-    currentViewMode === 'collapsed' ? 'expanded' : 'collapsed',
-  );
-}
-
-function addAdditionalText(): void {
-  const nodeLabels: string[] = additionalTextInputObject.value.inputLabels;
-  const defaultFields: PropertyConfig[] = getCollectionConfigFields(nodeLabels);
-  const newCollectionProperties: ICollection = {} as ICollection;
-
-  defaultFields.forEach((field: PropertyConfig) => {
-    newCollectionProperties[field.name] =
-      field?.required === true ? getDefaultValueForProperty(field.type) : null;
-  });
-
-  annotation.data.additionalTexts.push({
-    collection: {
-      nodeLabels,
-      data: {
-        ...newCollectionProperties,
-        uuid: crypto.randomUUID(),
-        label: `${nodeLabels.join(' | ')} for annotation ${annotation.data.properties.uuid}`,
-      } as ICollection,
-    },
-    text: {
-      // TODO: Text node labels should be made selectable too in the future
-      nodeLabels: [],
-      data: {
-        uuid: crypto.randomUUID(),
-        text: additionalTextInputObject.value.inputText,
-      } as IText,
-    },
-  });
-
-  finishAdditionalTextInputOperation();
-}
-
-function cancelAdditionalTextOperation(): void {
-  finishAdditionalTextInputOperation();
-}
-
-function handleDeleteAdditionalText(collectionUuid: string): void {
-  annotation.data.additionalTexts = annotation.data.additionalTexts.filter(
-    t => t.collection.data.uuid !== collectionUuid,
-  );
 }
 </script>
 
@@ -325,137 +170,12 @@ function handleDeleteAdditionalText(collectionUuid: string): void {
       v-if="config.hasNormdata === true"
       v-model="annotation.data.normdata"
     />
-    <Fieldset
+    <AnnotationFormAdditionalTextSection
       v-if="config.hasAdditionalTexts === true"
-      legend="Additional texts"
-      :toggle-button-props="{
-        title: `${propertiesAreCollapsed ? 'Expand' : 'Collapse'} additional texts`,
-      }"
-      :toggleable="true"
-      @toggle="additionalTextIsCollapsed = !additionalTextIsCollapsed"
-    >
-      <template #toggleicon>
-        <span :class="`pi pi-chevron-${additionalTextIsCollapsed ? 'down' : 'up'}`"></span>
-      </template>
-      <template
-        v-for="additionalText in annotation.data.additionalTexts"
-        :key="additionalText.collection.data.uuid"
-      >
-        <div class="additional-text-entry">
-          <div class="additional-text-header flex justify-content-between align-items-center">
-            <span v-if="additionalText.collection.nodeLabels.length > 0" class="font-semibold">{{
-              additionalText.collection.nodeLabels
-                .map((l: string) => camelCaseToTitleCase(l))
-                .join(' | ')
-            }}</span>
-            <span v-else class="font-italic"> No label provided yet... </span>
-            <Button
-              icon="pi pi-times"
-              severity="danger"
-              title="Remove this text from annotation"
-              @click="handleDeleteAdditionalText(additionalText.collection.data.uuid)"
-            />
-          </div>
-          <div class="flex align-items-center gap-2 overflow">
-            <a
-              :href="`/texts/${additionalText.text.data.uuid}`"
-              title="Open text in new editor tab"
-              class="flex align-items-center gap-1"
-              target="_blank"
-            >
-              <div
-                :class="`preview ${additionalTextStatusObject.get(additionalText.collection.data.uuid)}`"
-              >
-                {{ additionalText.text.data.text }}
-              </div>
-              <i class="pi pi-external-link"></i>
-            </a>
-          </div>
-          <Button
-            :icon="
-              additionalTextStatusObject.get(additionalText.collection.data.uuid) === 'collapsed'
-                ? 'pi pi-angle-double-down'
-                : 'pi pi-angle-double-up'
-            "
-            severity="secondary"
-            size="small"
-            class="w-full"
-            :title="
-              additionalTextStatusObject.get(additionalText.collection.data.uuid) === 'collapsed'
-                ? 'Show full text'
-                : 'Hide full text'
-            "
-            @click="toggleAdditionalTextPreviewMode(additionalText.collection.data.uuid)"
-          />
-          <Message
-            v-if="
-              !annotation.initialData.additionalTexts
-                .map(t => t.collection.data.uuid)
-                .includes(additionalText.collection.data.uuid)
-            "
-            severity="warn"
-          >
-            Save changes to edit new text...
-          </Message>
-        </div>
+      v-model="annotation.data.additionalTexts"
+      :initial-additional-texts="annotation.initialData.additionalTexts"
+    />
 
-        <hr />
-      </template>
-      <div>
-        <Button
-          v-show="additionalTextInputObject.mode === 'view'"
-          class="mt-2 w-full h-2rem"
-          icon="pi pi-plus"
-          size="small"
-          severity="secondary"
-          label="Add text"
-          title="Add new additional text entry"
-          :disabled="annotation.isTruncated"
-          @click="changeAdditionalTextSelectionMode('edit')"
-        />
-        <form
-          v-show="additionalTextInputObject.mode === 'edit'"
-          @submit.prevent="addAdditionalText"
-        >
-          <InputGroup>
-            <MultiSelect
-              v-model="additionalTextInputObject.inputLabels"
-              :options="additionalTextInputObject.availableLabels"
-              display="chip"
-              placeholder="Select collection labels"
-              class="text-center"
-              :filter="false"
-            >
-              <template #chip="{ value }">
-                <Tag :value="value" severity="contrast" class="mr-1" />
-              </template>
-            </MultiSelect>
-            <InputText
-              ref="additional-text-input"
-              required
-              v-model="additionalTextInputObject.inputText"
-              placeholder="Enter text"
-              title="Enter text"
-            />
-            <Button
-              type="submit"
-              icon="pi pi-check"
-              severity="secondary"
-              size="small"
-              title="Add new text"
-            />
-            <Button
-              type="button"
-              icon="pi pi-times"
-              severity="secondary"
-              size="small"
-              title="Cancel"
-              @click="cancelAdditionalTextOperation"
-            />
-          </InputGroup>
-        </form>
-      </div>
-    </Fieldset>
     <div class="edit-buttons flex justify-content-center">
       <Button
         icon="pi pi-angle-left"
@@ -537,15 +257,6 @@ function handleDeleteAdditionalText(collectionUuid: string): void {
   max-height: calc-size(auto);
 }
 
-.x {
-  background-color: white;
-  outline: 0;
-
-  &:not(:hover) {
-    border-color: transparent;
-  }
-}
-
 .created {
   background-color: lightgreen;
 }
@@ -557,10 +268,6 @@ function handleDeleteAdditionalText(collectionUuid: string): void {
 
 .form-label {
   flex-basis: 10rem;
-}
-
-.additional-text-header {
-  cursor: default;
 }
 
 .highlight {

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useAnnotationStore } from '../store/annotations';
 import { useCharactersStore } from '../store/characters';
 import { useEditorStore } from '../store/editor';
@@ -6,6 +7,7 @@ import { useGuidelinesStore } from '../store/guidelines';
 import { toggleTextHightlighting } from '../utils/helper/helper';
 import Button from 'primevue/button';
 import ConfirmPopup from 'primevue/confirmpopup';
+import Fieldset from 'primevue/fieldset';
 import Panel from 'primevue/panel';
 import Tag from 'primevue/tag';
 import { useConfirm } from 'primevue/useconfirm';
@@ -38,6 +40,7 @@ const { getAnnotationConfig, getAnnotationFields } = useGuidelinesStore();
 const config: AnnotationType = getAnnotationConfig(annotation.data.properties.type);
 // TODO: Maybe give whole config instead of only fields...?
 const propertyFields: PropertyConfig[] = getAnnotationFields(annotation.data.properties.type);
+const propertiesAreCollapsed = ref<boolean>(false);
 
 function handleDeleteAnnotation(event: MouseEvent, uuid: string): void {
   confirm.require({
@@ -128,7 +131,19 @@ function setRangeAnchorAtEnd(): void {
     <template #toggleicon="{ collapsed }">
       <i :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></i>
     </template>
-    <FormPropertiesSection v-model="annotation.data.properties" :fields="propertyFields" />
+    <Fieldset
+      legend="Properties"
+      :toggle-button-props="{
+        title: `${propertiesAreCollapsed ? 'Expand' : 'Collapse'} properties`,
+      }"
+      :toggleable="true"
+      @toggle="propertiesAreCollapsed = !propertiesAreCollapsed"
+    >
+      <template #toggleicon>
+        <span :class="`pi pi-chevron-${propertiesAreCollapsed ? 'down' : 'up'}`"></span>
+      </template>
+      <FormPropertiesSection v-model="annotation.data.properties" :fields="propertyFields" />
+    </Fieldset>
     <AnnotationFormNormdataSection
       v-if="config.hasNormdata === true"
       v-model="annotation.data.normdata"

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
-import { ref } from 'vue';
 import { useAnnotationStore } from '../store/annotations';
 import { useCharactersStore } from '../store/characters';
 import { useEditorStore } from '../store/editor';
 import { useGuidelinesStore } from '../store/guidelines';
-import { camelCaseToTitleCase, toggleTextHightlighting } from '../utils/helper/helper';
+import { toggleTextHightlighting } from '../utils/helper/helper';
 import Button from 'primevue/button';
 import ConfirmPopup from 'primevue/confirmpopup';
-import Fieldset from 'primevue/fieldset';
 import Panel from 'primevue/panel';
 import Tag from 'primevue/tag';
 import { useConfirm } from 'primevue/useconfirm';
@@ -15,8 +13,7 @@ import { Annotation, AnnotationType, PropertyConfig } from '../models/types';
 import AnnotationFormNormdataSection from './AnnotationFormNormdataSection.vue';
 import AnnotationFormAdditionalTextSection from './AnnotationFormAdditionalTextSection.vue';
 import AnnotationTypeIcon from './AnnotationTypeIcon.vue';
-import DataInputComponent from '../components/DataInputComponent.vue';
-import DataInputGroup from '../components/DataInputGroup.vue';
+import FormPropertiesSection from './FormPropertiesSection.vue';
 
 const props = defineProps<{
   annotation: Annotation;
@@ -39,9 +36,8 @@ const { newRangeAnchorUuid } = useEditorStore();
 const { getAnnotationConfig, getAnnotationFields } = useGuidelinesStore();
 
 const config: AnnotationType = getAnnotationConfig(annotation.data.properties.type);
-const fields: PropertyConfig[] = getAnnotationFields(annotation.data.properties.type);
-
-const propertiesAreCollapsed = ref<boolean>(false);
+// TODO: Maybe give whole config instead of only fields...?
+const propertyFields: PropertyConfig[] = getAnnotationFields(annotation.data.properties.type);
 
 function handleDeleteAnnotation(event: MouseEvent, uuid: string): void {
   confirm.require({
@@ -132,40 +128,7 @@ function setRangeAnchorAtEnd(): void {
     <template #toggleicon="{ collapsed }">
       <i :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></i>
     </template>
-    <Fieldset
-      legend="Properties"
-      :toggle-button-props="{
-        title: `${propertiesAreCollapsed ? 'Expand' : 'Collapse'} properties`,
-      }"
-      :toggleable="true"
-      @toggle="propertiesAreCollapsed = !propertiesAreCollapsed"
-    >
-      <template #toggleicon>
-        <span :class="`pi pi-chevron-${propertiesAreCollapsed ? 'down' : 'up'}`"></span>
-      </template>
-      <form>
-        <div
-          v-for="field in fields"
-          :key="field.name"
-          class="flex align-items-center gap-3 mb-3"
-          v-show="field.visible"
-        >
-          <label :for="field.name" class="form-label font-semibold"
-            >{{ camelCaseToTitleCase(field.name) }}
-          </label>
-          <DataInputGroup
-            v-if="field.type === 'array'"
-            v-model="annotation.data.properties[field.name]"
-            :config="field"
-          />
-          <DataInputComponent
-            v-else
-            v-model="annotation.data.properties[field.name]"
-            :config="field"
-          />
-        </div>
-      </form>
-    </Fieldset>
+    <FormPropertiesSection v-model="annotation.data.properties" :fields="propertyFields" />
     <AnnotationFormNormdataSection
       v-if="config.hasNormdata === true"
       v-model="annotation.data.normdata"

--- a/client/src/components/FormPropertiesSection.vue
+++ b/client/src/components/FormPropertiesSection.vue
@@ -8,6 +8,7 @@ const properties = defineModel<any>();
 
 const props = defineProps<{
   fields: PropertyConfig[];
+  mode?: 'edit' | 'view';
 }>();
 
 // const { getAnnotationFields } = useGuidelinesStore();
@@ -31,8 +32,14 @@ const props = defineProps<{
         v-if="field.type === 'array'"
         v-model="properties[field.name]"
         :config="field"
+        :mode="props.mode"
       />
-      <DataInputComponent v-else v-model="properties[field.name]" :config="field" />
+      <DataInputComponent
+        v-else
+        v-model="properties[field.name]"
+        :config="field"
+        :mode="props.mode"
+      />
     </div>
   </form>
 </template>

--- a/client/src/components/FormPropertiesSection.vue
+++ b/client/src/components/FormPropertiesSection.vue
@@ -1,7 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
 import { camelCaseToTitleCase } from '../utils/helper/helper';
-import Fieldset from 'primevue/fieldset';
 import { PropertyConfig } from '../models/types';
 import DataInputComponent from '../components/DataInputComponent.vue';
 import DataInputGroup from '../components/DataInputGroup.vue';
@@ -16,41 +14,27 @@ const props = defineProps<{
 
 // const config: AnnotationType = getAnnotationConfig(properties.value.type);
 // const fields: PropertyConfig[] = getAnnotationFields(properties.value.type);
-
-const propertiesAreCollapsed = ref<boolean>(false);
 </script>
 
 <template>
-  <Fieldset
-    legend="Properties"
-    :toggle-button-props="{
-      title: `${propertiesAreCollapsed ? 'Expand' : 'Collapse'} properties`,
-    }"
-    :toggleable="true"
-    @toggle="propertiesAreCollapsed = !propertiesAreCollapsed"
-  >
-    <template #toggleicon>
-      <span :class="`pi pi-chevron-${propertiesAreCollapsed ? 'down' : 'up'}`"></span>
-    </template>
-    <form>
-      <div
-        v-for="field in fields"
-        :key="field.name"
-        class="flex align-items-center gap-3 mb-3"
-        v-show="field.visible"
-      >
-        <label :for="field.name" class="form-label font-semibold"
-          >{{ camelCaseToTitleCase(field.name) }}
-        </label>
-        <DataInputGroup
-          v-if="field.type === 'array'"
-          v-model="properties[field.name]"
-          :config="field"
-        />
-        <DataInputComponent v-else v-model="properties[field.name]" :config="field" />
-      </div>
-    </form>
-  </Fieldset>
+  <form>
+    <div
+      v-for="field in fields"
+      :key="field.name"
+      class="flex align-items-center gap-3 mb-3"
+      v-show="field.visible"
+    >
+      <label :for="field.name" class="form-label font-semibold"
+        >{{ camelCaseToTitleCase(field.name) }}
+      </label>
+      <DataInputGroup
+        v-if="field.type === 'array'"
+        v-model="properties[field.name]"
+        :config="field"
+      />
+      <DataInputComponent v-else v-model="properties[field.name]" :config="field" />
+    </div>
+  </form>
 </template>
 
 <style scoped></style>

--- a/client/src/components/FormPropertiesSection.vue
+++ b/client/src/components/FormPropertiesSection.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { camelCaseToTitleCase } from '../utils/helper/helper';
+import Fieldset from 'primevue/fieldset';
+import { PropertyConfig } from '../models/types';
+import DataInputComponent from '../components/DataInputComponent.vue';
+import DataInputGroup from '../components/DataInputGroup.vue';
+
+const properties = defineModel<any>();
+
+const props = defineProps<{
+  fields: PropertyConfig[];
+}>();
+
+// const { getAnnotationFields } = useGuidelinesStore();
+
+// const config: AnnotationType = getAnnotationConfig(properties.value.type);
+// const fields: PropertyConfig[] = getAnnotationFields(properties.value.type);
+
+const propertiesAreCollapsed = ref<boolean>(false);
+</script>
+
+<template>
+  <Fieldset
+    legend="Properties"
+    :toggle-button-props="{
+      title: `${propertiesAreCollapsed ? 'Expand' : 'Collapse'} properties`,
+    }"
+    :toggleable="true"
+    @toggle="propertiesAreCollapsed = !propertiesAreCollapsed"
+  >
+    <template #toggleicon>
+      <span :class="`pi pi-chevron-${propertiesAreCollapsed ? 'down' : 'up'}`"></span>
+    </template>
+    <form>
+      <div
+        v-for="field in fields"
+        :key="field.name"
+        class="flex align-items-center gap-3 mb-3"
+        v-show="field.visible"
+      >
+        <label :for="field.name" class="form-label font-semibold"
+          >{{ camelCaseToTitleCase(field.name) }}
+        </label>
+        <DataInputGroup
+          v-if="field.type === 'array'"
+          v-model="properties[field.name]"
+          :config="field"
+        />
+        <DataInputComponent v-else v-model="properties[field.name]" :config="field" />
+      </div>
+    </form>
+  </Fieldset>
+</template>
+
+<style scoped></style>

--- a/client/src/models/IAnnotation.ts
+++ b/client/src/models/IAnnotation.ts
@@ -1,13 +1,9 @@
 export default interface IAnnotation {
   [keyof: string]: any;
-  comment: string;
-  commentInternal: string;
   endIndex: number;
-  originalText: string;
   startIndex: number;
   subtype: string | number;
   text: string;
   type: string;
-  url: string;
   uuid: string;
 }

--- a/client/src/models/IAnnotation.ts
+++ b/client/src/models/IAnnotation.ts
@@ -1,5 +1,5 @@
 export default interface IAnnotation {
-  [keyof: string]: string | number | boolean;
+  [keyof: string]: any;
   comment: string;
   commentInternal: string;
   endIndex: number;

--- a/client/src/models/IGuidelines.ts
+++ b/client/src/models/IGuidelines.ts
@@ -15,10 +15,7 @@ export interface IGuidelines {
       annotations: {
         additionalTexts: string[];
         types: AnnotationType[];
-        properties: {
-          system: PropertyConfig[];
-          base: PropertyConfig[];
-        };
+        properties: PropertyConfig[];
         resources: AnnotationConfigResource[];
       };
     }[];

--- a/client/src/models/IGuidelines.ts
+++ b/client/src/models/IGuidelines.ts
@@ -12,7 +12,25 @@ export interface IGuidelines {
         | 'primary'
         | 'secondary' /* Quick fix to determine which collections should be loaded into the overview table */;
       properties: PropertyConfig[];
+      annotations: {
+        additionalTexts: string[];
+        types: AnnotationType[];
+        properties: {
+          system: PropertyConfig[];
+          base: PropertyConfig[];
+        };
+        resources: AnnotationConfigResource[];
+      };
     }[];
+    annotations: {
+      additionalTexts: string[];
+      types: AnnotationType[];
+      properties: {
+        system: PropertyConfig[];
+        base: PropertyConfig[];
+      };
+      resources: AnnotationConfigResource[];
+    };
   };
   annotations: {
     additionalTexts: string[];

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -72,7 +72,7 @@ export type Collection = {
 };
 
 export type CollectionAccessObject = {
-  annotations: Annotation[];
+  annotations: AnnotationData[];
   collection: Collection;
   texts: Text[];
 };

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -72,6 +72,7 @@ export type Collection = {
 };
 
 export type CollectionAccessObject = {
+  annotations: Annotation[];
   collection: Collection;
   texts: Text[];
 };

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -54,13 +54,17 @@ export function useGuidelinesStore() {
   }
 
   /**
-   * Retrieves the properties an annotation of given node labels should should have. Used for rendering input fields in forms
-   * where properties of the annotation can be edited. Currently a hack.
+   * Retrieves the properties an annotation of given type should have in the context of a Collection with given node labels.
+   * Used for rendering input fields in forms where properties of the annotation can be edited. Currently a hack.
    *
-   * @param {string[]} nodeLabels - The node labels of the Collection.
-   * @return {PropertyConfig[]} The combined annotation fields for the collection type.
+   * @param {string[]} collectionNodeLabels - The node labels of the Collection.
+   * @param {string} annotationType - The type of the annotation.
+   * @return {PropertyConfig[]} The fields for the annotation type in the context of the Collection.
    */
-  function getCollectionAnnotationFields(nodeLabels: string[]): PropertyConfig[] {
+  function getCollectionAnnotationFields(
+    collectionNodeLabels: string[],
+    annotationType: string,
+  ): PropertyConfig[] {
     // TODO: This is a hack since the guidelines structure can change. It should be refactored to use the same structure as the annotations.
     const system: PropertyConfig[] =
       guidelines.value.collections.annotations?.properties?.system ?? [];
@@ -68,11 +72,11 @@ export function useGuidelinesStore() {
       guidelines.value.collections?.annotations?.properties?.base ?? [];
     const additional: PropertyConfig[] = guidelines.value.collections.types.reduce(
       (total: PropertyConfig[], curr) => {
-        if (nodeLabels.includes(curr.additionalLabel)) {
+        if (collectionNodeLabels.includes(curr.additionalLabel)) {
           const nestedSystem: PropertyConfig[] = curr.annotations?.properties?.system ?? [];
           const nestedBase: PropertyConfig[] = curr.annotations?.properties?.base ?? [];
           const nestedAdditional: PropertyConfig[] =
-            curr.annotations?.types?.flatMap(t => t.properties) ?? [];
+            curr.annotations?.types?.find(t => t.type === annotationType).properties ?? [];
           total.push(...nestedSystem, ...nestedBase, ...nestedAdditional);
         }
         return total;

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -76,7 +76,7 @@ export function useGuidelinesStore() {
           const nestedSystem: PropertyConfig[] = curr.annotations?.properties?.system ?? [];
           const nestedBase: PropertyConfig[] = curr.annotations?.properties?.base ?? [];
           const nestedAdditional: PropertyConfig[] =
-            curr.annotations?.types?.find(t => t.type === annotationType).properties ?? [];
+            curr.annotations?.types?.find(t => t.type === annotationType)?.properties ?? [];
           total.push(...nestedSystem, ...nestedBase, ...nestedAdditional);
         }
         return total;
@@ -142,6 +142,22 @@ export function useGuidelinesStore() {
     );
 
     return unique;
+  }
+
+  function getAvailableCollectionAnnotationTypes(collectionNodeLabels: string[]): AnnotationType[] {
+    const base: AnnotationType[] = guidelines.value.collections.annotations.types;
+    const additional: AnnotationType[] = guidelines.value.collections.types.reduce(
+      (total: AnnotationType[], curr) => {
+        if (collectionNodeLabels.includes(curr.additionalLabel)) {
+          const nested: AnnotationType[] = curr.annotations?.types ?? [];
+          total.push(...nested);
+        }
+        return total;
+      },
+      [],
+    );
+
+    return [...base, ...additional];
   }
 
   /**
@@ -228,6 +244,7 @@ export function useGuidelinesStore() {
     getAnnotationConfig,
     getAnnotationFields,
     getAvailableAnnotationResourceConfigs,
+    getAvailableCollectionAnnotationTypes,
     getAvailableCollectionLabels,
     getAvailableTextLabels,
     getCollectionAnnotationFields,

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -30,6 +30,8 @@ export function useGuidelinesStore() {
    * Retrieves the configuration for an annotation of given type. The configuration is an object containing internal information
    * as well as information about rendering behaviour (input type in forms, selection status etc.).
    *
+   * This function is only used for Text annotations, not Collections annotations.
+   *
    * @param {string} type - The type of the annotation.
    * @return {AnnotationType} The configuration of the annotation type.
    */
@@ -42,6 +44,8 @@ export function useGuidelinesStore() {
    * where properties of the annotation can be edited. The fields are retrieved from the annotation type itself (if it has any)
    * and from the global annotation properties.
    *
+   * This function is only used for Text annotations, not Collections annotations.
+   *
    * @param {string} type - The type of the annotation.
    * @return {PropertyConfig[]} The fields for the annotation type.
    */
@@ -50,7 +54,7 @@ export function useGuidelinesStore() {
     const base: PropertyConfig[] = guidelines.value.annotations.properties.base;
     const additional: PropertyConfig[] = getAnnotationConfig(type)?.properties ?? [];
 
-    return [...system, ...base, ...additional];
+    return [...additional, ...system, ...base];
   }
 
   /**
@@ -77,9 +81,9 @@ export function useGuidelinesStore() {
     const byCollectionType: PropertyConfig[] = guidelines.value.collections.types.reduce(
       (total: PropertyConfig[], curr) => {
         if (collectionNodeLabels.includes(curr.additionalLabel)) {
-          const nested: PropertyConfig[] = curr.annotations?.properties ?? [];
+          const nestedFields: PropertyConfig[] = curr.annotations?.properties ?? [];
 
-          total.push(...nested);
+          total.push(...nestedFields);
         }
 
         return total;
@@ -89,7 +93,7 @@ export function useGuidelinesStore() {
 
     // Properties for the given annotation type (no matter which level)
     const byAnnotationType: PropertyConfig[] =
-      getAvailableCollectionAnnotationTypes(collectionNodeLabels).find(
+      getAvailableCollectionAnnotationConfigs(collectionNodeLabels).find(
         t => t.type === annotationType,
       )?.properties ?? [];
 
@@ -101,17 +105,10 @@ export function useGuidelinesStore() {
     collectionLabels: string[],
     annotationType: string,
   ): AnnotationType {
-    const base: AnnotationType[] = guidelines.value?.collections.annotations?.types ?? [];
+    const availableConfigs: AnnotationType[] =
+      getAvailableCollectionAnnotationConfigs(collectionLabels);
 
-    const nested: AnnotationType[] = guidelines.value?.collections.types.flatMap(
-      t => t.annotations?.types ?? [],
-    );
-
-    // console.log(base);
-    // console.log(nested);
-    // debugger;
-
-    const desired: AnnotationType = [...base, ...nested].find(t => t.type === annotationType);
+    const desired: AnnotationType = availableConfigs.find(t => t.type === annotationType);
 
     return desired;
   }
@@ -153,7 +150,9 @@ export function useGuidelinesStore() {
     return unique;
   }
 
-  function getAvailableCollectionAnnotationTypes(collectionNodeLabels: string[]): AnnotationType[] {
+  function getAvailableCollectionAnnotationConfigs(
+    collectionNodeLabels: string[],
+  ): AnnotationType[] {
     const base: AnnotationType[] = guidelines.value.collections.annotations.types;
     const additional: AnnotationType[] = guidelines.value.collections.types.reduce(
       (total: AnnotationType[], curr) => {
@@ -253,7 +252,7 @@ export function useGuidelinesStore() {
     getAnnotationConfig,
     getAnnotationFields,
     getAvailableAnnotationResourceConfigs,
-    getAvailableCollectionAnnotationTypes,
+    getAvailableCollectionAnnotationConfigs,
     getAvailableCollectionLabels,
     getAvailableTextLabels,
     getCollectionAnnotationFields,

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -35,6 +35,7 @@ import ConfirmPopup from 'primevue/confirmpopup';
 import DataTable from 'primevue/datatable';
 import InputText from 'primevue/inputtext';
 import MultiSelect from 'primevue/multiselect';
+import SplitButton from 'primevue/splitbutton';
 import Splitter from 'primevue/splitter';
 import SplitterPanel from 'primevue/splitterpanel';
 import Tag from 'primevue/tag';
@@ -52,6 +53,15 @@ type TextTableEntry = {
   text: string;
   uuid: string;
 };
+
+const availabeAnnotationTypes: string[] = ['AnnotationType1', 'AnnotationType2', 'AnnotationType3'];
+const dropdownOptions = availabeAnnotationTypes.map((type: string | number) => {
+  return {
+    label: type.toString(),
+    command: () => console.log(`New ${type} was created`),
+  };
+});
+
 const route: RouteLocationNormalizedLoaded = useRoute();
 const toast: ToastServiceMethods = useToast();
 const confirm = useConfirm();
@@ -569,6 +579,14 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               :initial-additional-texts="cloneDeep(annotation.additionalTexts)"
             />
           </Panel>
+          <SplitButton
+            severity="secondary"
+            outlined
+            raised
+            label="Add new annotation"
+            :style="{ height: '35px' }"
+            :model="dropdownOptions"
+          />
         </div>
       </SplitterPanel>
       <SplitterPanel class="overflow-y-auto">

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -662,7 +662,11 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               "
               :mode="mode"
               v-model="annotation.additionalTexts"
-              :initial-additional-texts="cloneDeep(annotation.additionalTexts)"
+              :initial-additional-texts="
+                initialCollectionAccessObject.annotations.find(
+                  a => a.properties.uuid === annotation.properties.uuid,
+                ).additionalTexts
+              "
             />
             <div class="action-buttons flex justify-content-center">
               <Button

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -63,7 +63,7 @@ const {
   guidelines,
   getAllCollectionConfigFields,
   getAvailableCollectionLabels,
-  getAvailableCollectionAnnotationTypes,
+  getAvailableCollectionAnnotationConfigs,
   getAvailableTextLabels,
   getCollectionAnnotationConfig,
   getCollectionAnnotationFields,
@@ -98,7 +98,7 @@ const collectionFields: ComputedRef<PropertyConfig[]> = computed(() => {
 });
 
 const availabeAnnotationTypes: ComputedRef<AnnotationType[]> = computed(() =>
-  getAvailableCollectionAnnotationTypes(collectionAccessObject.value.collection.nodeLabels),
+  getAvailableCollectionAnnotationConfigs(collectionAccessObject.value.collection.nodeLabels),
 );
 
 const tableData: ComputedRef<TextTableEntry[]> = computed(() => {

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -665,7 +665,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               :initial-additional-texts="
                 initialCollectionAccessObject.annotations.find(
                   a => a.properties.uuid === annotation.properties.uuid,
-                ).additionalTexts
+                )?.additionalTexts ?? []
               "
             />
             <div class="action-buttons flex justify-content-center">
@@ -686,6 +686,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               v-for="type in availabeAnnotationTypes"
               :annotationType="type.type"
               :collection-node-labels="collectionAccessObject.collection.nodeLabels"
+              :mode="mode"
               @add-annotation="handleAddNewAnnotation"
             />
           </div>

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -125,6 +125,12 @@ onMounted(async (): Promise<void> => {
   isLoading.value = false;
 });
 
+function deleteAnnotation(uuid: string): void {
+  collectionAccessObject.value.annotations = collectionAccessObject.value.annotations.filter(
+    a => a.properties.uuid !== uuid,
+  );
+}
+
 /**
  * Fills in any missing collection properties with the type-specific default value.
  *
@@ -186,6 +192,27 @@ function handleBeforeUnload(event: BeforeUnloadEvent): void {
 
 async function handleCopy(): Promise<void> {
   await navigator.clipboard.writeText(collectionAccessObject.value.collection.data.uuid);
+}
+
+function handleDeleteAnnotation(event: MouseEvent, uuid: string): void {
+  confirm.require({
+    target: event.currentTarget as HTMLButtonElement,
+    message: 'Do you want to delete this annotation?',
+    icon: 'pi pi-exclamation-triangle',
+    rejectProps: {
+      label: 'Cancel',
+      severity: 'secondary',
+      outlined: true,
+      title: 'Cancel',
+    },
+    acceptProps: {
+      label: 'Delete',
+      severity: 'danger',
+      title: 'Delete annotation',
+    },
+    accept: () => deleteAnnotation(uuid),
+    reject: () => {},
+  });
 }
 
 async function handleDeleteText(uuid: string) {
@@ -634,6 +661,17 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               v-model="annotation.additionalTexts"
               :initial-additional-texts="cloneDeep(annotation.additionalTexts)"
             />
+            <div class="action-buttons flex justify-content-center">
+              <Button
+                label="Delete"
+                title="Delete annotation"
+                severity="danger"
+                icon="pi pi-trash"
+                size="small"
+                @click="handleDeleteAnnotation($event, annotation.properties.uuid)"
+              />
+            </div>
+            <ConfirmPopup></ConfirmPopup>
           </Panel>
           <div class="annotation-button-pane flex flex-wrap gap-3 py-3">
             <CollectionAnnotationButton

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -598,6 +598,15 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
             </div>
           </form>
           <h2 class="text-center">Annotations</h2>
+          <div v-if="mode === 'edit'" class="annotation-button-pane flex flex-wrap gap-3 py-3">
+            <CollectionAnnotationButton
+              v-for="type in availabeAnnotationTypes"
+              :annotationType="type.type"
+              :collection-node-labels="collectionAccessObject.collection.nodeLabels"
+              :mode="mode"
+              @add-annotation="handleAddNewAnnotation"
+            />
+          </div>
           <Panel
             v-for="annotation in collectionAccessObject.annotations"
             class="annotation-form mb-3"
@@ -621,7 +630,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
             <template #toggleicon="{ collapsed }">
               <i :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></i>
             </template>
-            <Fieldset
+            <!-- <Fieldset
               legend="Properties"
               :toggle-button-props="{
                 title: `${propertiesAreCollapsed ? 'Expand' : 'Collapse'} properties`,
@@ -642,7 +651,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
                 "
                 :mode="mode"
               />
-            </Fieldset>
+            </Fieldset> -->
             <AnnotationFormNormdataSection
               v-if="
                 getCollectionAnnotationConfig(
@@ -653,7 +662,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               :mode="mode"
               v-model="annotation.normdata"
             />
-            <AnnotationFormAdditionalTextSection
+            <!-- <AnnotationFormAdditionalTextSection
               v-if="
                 getCollectionAnnotationConfig(
                   collectionAccessObject.collection.nodeLabels,
@@ -667,7 +676,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
                   a => a.properties.uuid === annotation.properties.uuid,
                 )?.additionalTexts ?? []
               "
-            />
+            /> -->
             <div class="action-buttons flex justify-content-center">
               <Button
                 v-if="mode === 'edit'"
@@ -681,15 +690,6 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
             </div>
             <ConfirmPopup></ConfirmPopup>
           </Panel>
-          <div class="annotation-button-pane flex flex-wrap gap-3 py-3">
-            <CollectionAnnotationButton
-              v-for="type in availabeAnnotationTypes"
-              :annotationType="type.type"
-              :collection-node-labels="collectionAccessObject.collection.nodeLabels"
-              :mode="mode"
-              @add-annotation="handleAddNewAnnotation"
-            />
-          </div>
         </div>
       </SplitterPanel>
       <SplitterPanel class="overflow-y-auto">

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -640,6 +640,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
                     annotation.properties.type,
                   )
                 "
+                :mode="mode"
               />
             </Fieldset>
             <AnnotationFormNormdataSection
@@ -649,6 +650,7 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
                   annotation.properties.type,
                 ).hasNormdata === true
               "
+              :mode="mode"
               v-model="annotation.normdata"
             />
             <AnnotationFormAdditionalTextSection
@@ -658,11 +660,13 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
                   annotation.properties.type,
                 ).hasAdditionalTexts === true
               "
+              :mode="mode"
               v-model="annotation.additionalTexts"
               :initial-additional-texts="cloneDeep(annotation.additionalTexts)"
             />
             <div class="action-buttons flex justify-content-center">
               <Button
+                v-if="mode === 'edit'"
                 label="Delete"
                 title="Delete annotation"
                 severity="danger"

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -9,6 +9,7 @@ import {
 import { useGuidelinesStore } from '../store/guidelines';
 import AnnotationFormAdditionalTextSection from '../components/AnnotationFormAdditionalTextSection.vue';
 import AnnotationFormNormdataSection from '../components/AnnotationFormNormdataSection.vue';
+import CollectionAnnotationButton from '../components/CollectionAnnotationButton.vue';
 import CollectionError from '../components/CollectionError.vue';
 import DataInputComponent from '../components/DataInputComponent.vue';
 import DataInputGroup from '../components/DataInputGroup.vue';
@@ -24,6 +25,7 @@ import {
 import { IGuidelines } from '../models/IGuidelines';
 import {
   AnnotationData,
+  AnnotationType,
   CollectionAccessObject,
   CollectionPostData,
   PropertyConfig,
@@ -35,7 +37,6 @@ import ConfirmPopup from 'primevue/confirmpopup';
 import DataTable from 'primevue/datatable';
 import InputText from 'primevue/inputtext';
 import MultiSelect from 'primevue/multiselect';
-import SplitButton from 'primevue/splitbutton';
 import Splitter from 'primevue/splitter';
 import SplitterPanel from 'primevue/splitterpanel';
 import Tag from 'primevue/tag';
@@ -54,14 +55,6 @@ type TextTableEntry = {
   uuid: string;
 };
 
-const availabeAnnotationTypes: string[] = ['AnnotationType1', 'AnnotationType2', 'AnnotationType3'];
-const dropdownOptions = availabeAnnotationTypes.map((type: string | number) => {
-  return {
-    label: type.toString(),
-    command: () => console.log(`New ${type} was created`),
-  };
-});
-
 const route: RouteLocationNormalizedLoaded = useRoute();
 const toast: ToastServiceMethods = useToast();
 const confirm = useConfirm();
@@ -70,6 +63,7 @@ const {
   guidelines,
   getAllCollectionConfigFields,
   getAvailableCollectionLabels,
+  getAvailableCollectionAnnotationTypes,
   getAvailableTextLabels,
   getCollectionAnnotationConfig,
   getCollectionAnnotationFields,
@@ -102,6 +96,10 @@ const collectionFields: ComputedRef<PropertyConfig[]> = computed(() => {
     ? getCollectionConfigFields(collectionAccessObject.value.collection.nodeLabels)
     : [];
 });
+
+const availabeAnnotationTypes: ComputedRef<AnnotationType[]> = computed(() =>
+  getAvailableCollectionAnnotationTypes(collectionAccessObject.value.collection.nodeLabels),
+);
 
 const tableData: ComputedRef<TextTableEntry[]> = computed(() => {
   return collectionAccessObject.value.texts.map((text: Text) => {
@@ -162,6 +160,12 @@ async function getGuidelines(): Promise<void> {
   } catch (error: unknown) {
     console.error('Error fetching guidelines:', error);
   }
+}
+
+function handleAddNewAnnotation(newAnnotation: AnnotationData): void {
+  console.log(newAnnotation);
+
+  collectionAccessObject.value.annotations.push(newAnnotation);
 }
 
 function handleAddNewText(): void {
@@ -579,14 +583,14 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               :initial-additional-texts="cloneDeep(annotation.additionalTexts)"
             />
           </Panel>
-          <SplitButton
-            severity="secondary"
-            outlined
-            raised
-            label="Add new annotation"
-            :style="{ height: '35px' }"
-            :model="dropdownOptions"
-          />
+          <div class="annotation-button-pane flex flex-wrap gap-3 py-3">
+            <CollectionAnnotationButton
+              v-for="type in availabeAnnotationTypes"
+              :annotationType="type.type"
+              :collection-node-labels="collectionAccessObject.collection.nodeLabels"
+              @add-annotation="handleAddNewAnnotation"
+            />
+          </div>
         </div>
       </SplitterPanel>
       <SplitterPanel class="overflow-y-auto">

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -542,7 +542,10 @@ function shiftText(textUuid: string, direction: 'up' | 'down') {
               <FormPropertiesSection
                 v-model="annotation.properties"
                 :fields="
-                  getCollectionAnnotationFields(collectionAccessObject.collection.nodeLabels)
+                  getCollectionAnnotationFields(
+                    collectionAccessObject.collection.nodeLabels,
+                    annotation.properties.type,
+                  )
                 "
               />
             </Fieldset>

--- a/client/src/views/CollectionEntry.vue
+++ b/client/src/views/CollectionEntry.vue
@@ -7,14 +7,12 @@ import {
   useRoute,
 } from 'vue-router';
 import { useGuidelinesStore } from '../store/guidelines';
-import AnnotationFormAdditionalTextSection from '../components/AnnotationFormAdditionalTextSection.vue';
 import AnnotationFormNormdataSection from '../components/AnnotationFormNormdataSection.vue';
 import CollectionAnnotationButton from '../components/CollectionAnnotationButton.vue';
 import CollectionError from '../components/CollectionError.vue';
 import DataInputComponent from '../components/DataInputComponent.vue';
 import DataInputGroup from '../components/DataInputGroup.vue';
 import LoadingSpinner from '../components/LoadingSpinner.vue';
-import FormPropertiesSection from '../components/FormPropertiesSection.vue';
 import {
   areSetsEqual,
   buildFetchUrl,
@@ -45,7 +43,6 @@ import { ToastServiceMethods } from 'primevue/toastservice';
 import { useConfirm } from 'primevue/useconfirm';
 import { useToast } from 'primevue/usetoast';
 import { useTitle } from '@vueuse/core';
-import Fieldset from 'primevue/fieldset';
 import Panel from 'primevue/panel';
 
 type TextTableEntry = {
@@ -66,7 +63,6 @@ const {
   getAvailableCollectionAnnotationConfigs,
   getAvailableTextLabels,
   getCollectionAnnotationConfig,
-  getCollectionAnnotationFields,
   getCollectionConfigFields,
   initializeGuidelines,
 } = useGuidelinesStore();
@@ -77,7 +73,6 @@ const collectionAccessObject = ref<CollectionAccessObject | null>(null);
 const isValidCollection = ref<boolean>(false);
 const initialCollectionAccessObject = ref<CollectionAccessObject | null>(null);
 const mode = ref<'view' | 'edit'>('view');
-const propertiesAreCollapsed = ref<boolean>(false);
 
 // Initial pageload
 const isLoading = ref<boolean>(true);

--- a/guidelines.development.json
+++ b/guidelines.development.json
@@ -49,6 +49,17 @@
               "category": "none",
               "defaultSelected": true,
               "isZeroPoint": false,
+              "hasNormdata": true,
+              "hasAdditionalTexts": true,
+              "annotations": {
+                "types": [],
+                "properties": {
+                  "system": [],
+                  "base": []
+                },
+                "resources": [],
+                "additionalTexts": []
+              },
               "properties": [
                 {
                   "name": "senderNickname",
@@ -64,6 +75,17 @@
               "category": "none",
               "defaultSelected": true,
               "isZeroPoint": false,
+              "hasNormdata": true,
+              "hasAdditionalTexts": true,
+              "annotations": {
+                "types": [],
+                "properties": {
+                  "system": [],
+                  "base": []
+                },
+                "resources": [],
+                "additionalTexts": []
+              },
               "properties": [
                 {
                   "name": "receiverNickname",

--- a/guidelines.development.json
+++ b/guidelines.development.json
@@ -41,7 +41,67 @@
             "editable": true,
             "visible": true
           }
-        ]
+        ],
+        "annotations": {
+          "types": [
+            {
+              "type": "sentBy",
+              "category": "none",
+              "defaultSelected": true,
+              "isZeroPoint": false,
+              "properties": [
+                {
+                  "name": "senderNickname",
+                  "type": "string",
+                  "required": false,
+                  "editable": true,
+                  "visible": true
+                }
+              ]
+            },
+            {
+              "type": "receivedBy",
+              "category": "none",
+              "defaultSelected": true,
+              "isZeroPoint": false,
+              "properties": [
+                {
+                  "name": "receiverNickname",
+                  "type": "string",
+                  "required": false,
+                  "editable": true,
+                  "visible": true
+                }
+              ]
+            }
+          ],
+          "properties": {
+            "system": [
+              {
+                "name": "type",
+                "type": "string",
+                "required": true,
+                "editable": false,
+                "visible": true
+              },
+              {
+                "name": "text",
+                "type": "string",
+                "required": true,
+                "editable": false,
+                "visible": true
+              }
+            ],
+            "base": []
+          },
+          "resources": [
+            {
+              "category": "persons",
+              "nodeLabel": "Person"
+            }
+          ],
+          "additionalTexts": []
+        }
       },
       {
         "additionalLabel": "Comment",
@@ -195,7 +255,16 @@
           }
         ]
       }
-    ]
+    ],
+    "annotations": {
+      "types": [],
+      "properties": {
+        "system": [],
+        "base": []
+      },
+      "resources": [],
+      "additionalTexts": []
+    }
   },
   "annotations": {
     "types": [

--- a/guidelines.development.json
+++ b/guidelines.development.json
@@ -35,7 +35,7 @@
             "visible": true
           },
           {
-            "name": "receiver",
+            "name": "receivedPerson",
             "type": "string",
             "required": false,
             "editable": true,
@@ -45,7 +45,7 @@
         "annotations": {
           "types": [
             {
-              "type": "sentBy",
+              "type": "sentPerson",
               "category": "none",
               "defaultSelected": true,
               "isZeroPoint": false,

--- a/guidelines.development.json
+++ b/guidelines.development.json
@@ -35,7 +35,7 @@
             "visible": true
           },
           {
-            "name": "receivedPerson",
+            "name": "receiver",
             "type": "string",
             "required": false,
             "editable": true,
@@ -62,7 +62,7 @@
               ]
             },
             {
-              "type": "receivedBy",
+              "type": "receivedPerson",
               "category": "none",
               "defaultSelected": true,
               "isZeroPoint": false,

--- a/guidelines.development.json
+++ b/guidelines.development.json
@@ -51,20 +51,11 @@
               "isZeroPoint": false,
               "hasNormdata": true,
               "hasAdditionalTexts": true,
-              "annotations": {
-                "types": [],
-                "properties": {
-                  "system": [],
-                  "base": []
-                },
-                "resources": [],
-                "additionalTexts": []
-              },
               "properties": [
                 {
                   "name": "senderNickname",
                   "type": "string",
-                  "required": false,
+                  "required": true,
                   "editable": true,
                   "visible": true
                 }
@@ -77,45 +68,26 @@
               "isZeroPoint": false,
               "hasNormdata": true,
               "hasAdditionalTexts": true,
-              "annotations": {
-                "types": [],
-                "properties": {
-                  "system": [],
-                  "base": []
-                },
-                "resources": [],
-                "additionalTexts": []
-              },
               "properties": [
                 {
                   "name": "receiverNickname",
                   "type": "string",
-                  "required": false,
+                  "required": true,
                   "editable": true,
                   "visible": true
                 }
               ]
             }
           ],
-          "properties": {
-            "system": [
-              {
-                "name": "type",
-                "type": "string",
-                "required": true,
-                "editable": false,
-                "visible": true
-              },
-              {
-                "name": "text",
-                "type": "string",
-                "required": true,
-                "editable": false,
-                "visible": true
-              }
-            ],
-            "base": []
-          },
+          "properties": [
+            {
+              "name": "type",
+              "type": "string",
+              "required": true,
+              "editable": false,
+              "visible": true
+            }
+          ],
           "resources": [
             {
               "category": "persons",
@@ -279,11 +251,45 @@
       }
     ],
     "annotations": {
-      "types": [],
       "properties": {
-        "system": [],
-        "base": []
+        "system": [
+          {
+            "name": "topLevelSystem",
+            "type": "string",
+            "required": true,
+            "editable": true,
+            "visible": true
+          }
+        ],
+        "base": [
+          {
+            "name": "topLevelBase",
+            "type": "string",
+            "required": true,
+            "editable": true,
+            "visible": true
+          }
+        ]
       },
+      "types": [
+        {
+          "type": "topLevelTyType",
+          "category": "none",
+          "defaultSelected": true,
+          "isZeroPoint": false,
+          "hasNormdata": true,
+          "hasAdditionalTexts": true,
+          "properties": [
+            {
+              "name": "baseWithTypeProp",
+              "type": "string",
+              "required": true,
+              "editable": true,
+              "visible": true
+            }
+          ]
+        }
+      ],
       "resources": [],
       "additionalTexts": []
     }

--- a/server/src/models/IAnnotation.ts
+++ b/server/src/models/IAnnotation.ts
@@ -1,13 +1,9 @@
 export default interface IAnnotation {
   [keyof: string]: any;
-  comment: string;
-  commentInternal: string;
   endIndex: number;
-  originalText: string;
   startIndex: number;
   subtype: string | number;
   text: string;
   type: string;
-  url: string;
   uuid: string;
 }

--- a/server/src/models/IAnnotation.ts
+++ b/server/src/models/IAnnotation.ts
@@ -1,5 +1,5 @@
 export default interface IAnnotation {
-  [keyof: string]: string | number | boolean;
+  [keyof: string]: any;
   comment: string;
   commentInternal: string;
   endIndex: number;

--- a/server/src/models/IGuidelines.ts
+++ b/server/src/models/IGuidelines.ts
@@ -15,10 +15,7 @@ export interface IGuidelines {
       annotations: {
         additionalTexts: string[];
         types: AnnotationType[];
-        properties: {
-          system: PropertyConfig[];
-          base: PropertyConfig[];
-        };
+        properties: PropertyConfig[];
         resources: AnnotationConfigResource[];
       };
     }[];

--- a/server/src/models/IGuidelines.ts
+++ b/server/src/models/IGuidelines.ts
@@ -12,7 +12,25 @@ export interface IGuidelines {
         | 'primary'
         | 'secondary' /* Quick fix to determine which collections should be loaded into the overview table */;
       properties: PropertyConfig[];
+      annotations: {
+        additionalTexts: string[];
+        types: AnnotationType[];
+        properties: {
+          system: PropertyConfig[];
+          base: PropertyConfig[];
+        };
+        resources: AnnotationConfigResource[];
+      };
     }[];
+    annotations: {
+      additionalTexts: string[];
+      types: AnnotationType[];
+      properties: {
+        system: PropertyConfig[];
+        base: PropertyConfig[];
+      };
+      resources: AnnotationConfigResource[];
+    };
   };
   annotations: {
     additionalTexts: string[];

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -72,7 +72,7 @@ export type Collection = {
 };
 
 export type CollectionAccessObject = {
-  annotations: Annotation[];
+  annotations: AnnotationData[];
   collection: Collection;
   texts: Text[];
 };

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -72,6 +72,7 @@ export type Collection = {
 };
 
 export type CollectionAccessObject = {
+  annotations: Annotation[];
   collection: Collection;
   texts: Text[];
 };

--- a/server/src/routes/annotations.routes.ts
+++ b/server/src/routes/annotations.routes.ts
@@ -26,6 +26,7 @@ router.post('/', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const updatedAnnotations: IAnnotation[] = await annotationService.saveAnnotations(
       textUuid,
+      'Text',
       annotations as Annotation[],
     );
 

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -1,11 +1,13 @@
 import express, { Request, Response, Router, NextFunction } from 'express';
 import characterRoutes from './characters.routes.js';
 import annotationRoutes from './annotations.routes.js';
+import AnnotationService from '../services/annotation.service.js';
 import CollectionService from '../services/collection.service.js';
 import GuidelinesService from '../services/guidelines.service.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
 import {
+  AnnotationData,
   Collection,
   CollectionAccessObject,
   CollectionPostData,
@@ -16,6 +18,7 @@ import { getPagination } from '../utils/helper.js';
 const router: Router = express.Router({ mergeParams: true });
 
 const collectionService: CollectionService = new CollectionService();
+const annotationService: AnnotationService = new AnnotationService();
 const guidelineService: GuidelinesService = new GuidelinesService();
 
 router.get('/', async (req: Request, res: Response, next: NextFunction) => {
@@ -66,10 +69,16 @@ router.get('/:uuid', async (req: Request, res: Response, next: NextFunction) => 
   const uuid: string = req.params.uuid;
 
   try {
-    const collection: CollectionAccessObject =
-      await collectionService.getExtendedCollectionById(uuid);
+    const { collection, texts } = await collectionService.getExtendedCollectionById(uuid);
+    const annotations: AnnotationData[] = await annotationService.getAnnotations(uuid);
 
-    res.status(200).json(collection);
+    const collectionAccessObject: CollectionAccessObject = {
+      collection,
+      texts,
+      annotations,
+    };
+
+    res.status(200).json(collectionAccessObject);
   } catch (error: unknown) {
     next(error);
   }

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -6,7 +6,9 @@ import CollectionService from '../services/collection.service.js';
 import GuidelinesService from '../services/guidelines.service.js';
 import ICollection from '../models/ICollection.js';
 import { IGuidelines } from '../models/IGuidelines.js';
+import IAnnotation from '../models/IAnnotation.js';
 import {
+  Annotation,
   AnnotationData,
   Collection,
   CollectionAccessObject,
@@ -90,6 +92,12 @@ router.post('/:uuid', async (req: Request, res: Response, next: NextFunction) =>
 
   try {
     const collection: ICollection = await collectionService.updateCollection(uuid, data);
+
+    const annotationObjects = annotationService.createAnnotationObjectsFromCollection(data);
+    const updatedAnnotations: IAnnotation[] = await annotationService.saveAnnotations(
+      uuid,
+      annotationObjects as Annotation[],
+    );
 
     res.status(200).json(collection);
   } catch (error: unknown) {

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -53,13 +53,10 @@ router.get('/', async (req: Request, res: Response, next: NextFunction) => {
 });
 
 router.post('/', async (req: Request, res: Response, next: NextFunction) => {
-  const { data, nodeLabels }: Collection = req.body;
+  const data: CollectionAccessObject = req.body;
 
   try {
-    const newCollection: ICollection = await collectionService.createNewCollection(
-      data,
-      nodeLabels,
-    );
+    const newCollection: ICollection = await collectionService.createNewCollection(data);
 
     res.status(201).json(newCollection);
   } catch (error: unknown) {

--- a/server/src/routes/collections.routes.ts
+++ b/server/src/routes/collections.routes.ts
@@ -96,6 +96,7 @@ router.post('/:uuid', async (req: Request, res: Response, next: NextFunction) =>
     const annotationObjects = annotationService.createAnnotationObjectsFromCollection(data);
     const updatedAnnotations: IAnnotation[] = await annotationService.saveAnnotations(
       uuid,
+      'Collection',
       annotationObjects as Annotation[],
     );
 

--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -40,6 +40,17 @@ type CreatedAdditionalText = Omit<AdditionalText, 'text'> & {
 };
 
 export default class AnnotationService {
+  /**
+   * Process the annotations of the given collection to create annotation objects for saving. These objects contain
+   * additional information or at least entries with empty arrays.
+   *
+   * The method is used to give collection anontations the same structure as text annotations, so that they
+   * can be further processed and saved the same way. When the day has come where there are generic type handling
+   * and data structures for annotations, this will be done in a more elegant way.
+   *
+   * @param {CollectionPostData} collection - The collection containing the annotations.
+   * @returns {Partial<Annotation>[]} An array of annotation objects.
+   */
   public createAnnotationObjectsFromCollection(
     collection: CollectionPostData,
   ): Partial<Annotation>[] {
@@ -47,7 +58,6 @@ export default class AnnotationService {
     const initialAnnotations: AnnotationData[] = collection.initialData.annotations;
 
     const annotationUuids: string[] = annotations.map(a => a.properties.uuid);
-    const initialAnnotationUuids: string[] = initialAnnotations.map(a => a.properties.uuid);
 
     const annotationObjects: Partial<Annotation>[] = [];
 
@@ -76,6 +86,7 @@ export default class AnnotationService {
         characterUuids: [],
         data: annotation,
         // No initial data -> annotation is new -> Use empty values for normdata and additional texts
+        // to create a minimal structure for further processing. Properties will not be used anyway.
         initialData:
           initial ??
           ({

--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -39,14 +39,14 @@ type CreatedAdditionalText = Omit<AdditionalText, 'text'> & {
 };
 
 export default class AnnotationService {
-  public async getAnnotations(textUuid: string): Promise<AnnotationData[]> {
+  public async getAnnotations(nodeUuid: string): Promise<AnnotationData[]> {
     const guidelineService: GuidelinesService = new GuidelinesService();
     const resources: AnnotationConfigResource[] =
       await guidelineService.getAvailableAnnotationResourceConfigs();
 
     const query: string = `
     // Match all annotations for given selection
-    MATCH (t:Text {uuid: $textUuid})-[:HAS_ANNOTATION]->(a:Annotation)
+    MATCH (n:Text|Collection {uuid: $nodeUuid})-[:HAS_ANNOTATION]->(a:Annotation)
 
     // Fetch additional nodes by label defined in the guidelines
     WITH a
@@ -97,7 +97,10 @@ export default class AnnotationService {
     }) AS annotations
     `;
 
-    const result: QueryResult = await Neo4jDriver.runQuery(query, { textUuid, resources });
+    const result: QueryResult = await Neo4jDriver.runQuery(query, {
+      nodeUuid,
+      resources,
+    });
     const rawAnnotations: AnnotationData[] = result.records[0]?.get('annotations');
 
     const annotations: AnnotationData[] = rawAnnotations.map(annotation =>

--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -52,16 +52,16 @@ export default class AnnotationService {
     const annotationObjects: Partial<Annotation>[] = [];
 
     // Create annotation objects for old annotations-> they will be deleted
-    initialAnnotations.forEach(annotation => {
+    initialAnnotations.forEach(anno => {
       // Get only annotations that were deleted in by the user
-      if (annotationUuids.includes(annotation.properties.uuid)) {
+      if (annotationUuids.includes(anno.properties.uuid)) {
         return;
       }
 
       annotationObjects.push({
         characterUuids: [],
-        data: annotation,
-        initialData: annotation,
+        data: anno,
+        initialData: anno,
         status: 'deleted',
       });
     });
@@ -75,8 +75,14 @@ export default class AnnotationService {
       annotationObjects.push({
         characterUuids: [],
         data: annotation,
-        // New annotations dont have initial data -> use the current data
-        initialData: initial ?? annotation,
+        // No initial data -> annotation is new -> Use empty values for normdata and additional texts
+        initialData:
+          initial ??
+          ({
+            normdata: {},
+            additionalTexts: [],
+            properties: {} as IAnnotation,
+          } as AnnotationData),
         // "existing" or "created" doesn't matter here since they are handled the same way
         status: 'existing',
       });

--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -286,7 +286,7 @@ export default class AnnotationService {
 
         // Match subgraph
         CALL apoc.path.subgraphNodes(a, {
-            relationshipFilter: 'REFERS_TO>,<PART_OF,HAS_ANNOTATION>',
+            relationshipFilter: 'REFERS_TO>|<PART_OF|HAS_ANNOTATION>',
             labelFilter: 'Collection|Text|Annotation'
         }) YIELD node
 
@@ -343,7 +343,7 @@ export default class AnnotationService {
         
         // Match subgraph
         CALL apoc.path.subgraphNodes(c, {
-            relationshipFilter: '<PART_OF,HAS_ANNOTATION>,REFERS_TO>',
+            relationshipFilter: '<PART_OF|HAS_ANNOTATION>|REFERS_TO>',
             labelFilter: 'Collection|Text|Annotation'
         }) YIELD node
 

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -3,7 +3,9 @@ import Neo4jDriver from '../database/neo4j.js';
 import GuidelinesService from './guidelines.service.js';
 import { toNativeTypes, toNeo4jTypes } from '../utils/helper.js';
 import NotFoundError from '../errors/not-found.error.js';
+import IAnnotation from '../models/IAnnotation.js';
 import ICollection from '../models/ICollection.js';
+import { IGuidelines } from '../models/IGuidelines.js';
 import {
   CollectionAccessObject,
   PaginationResult,
@@ -46,6 +48,7 @@ export default class CollectionService {
     RETURN count(c) AS totalRecords
     `;
 
+    // TODO: Should Annotations be included here?
     const dataQuery: string = `
     MATCH (c:Collection:${additionalLabel})
     WHERE toLower(c.label) CONTAINS $search
@@ -185,30 +188,139 @@ export default class CollectionService {
   }
 
   /**
-   * Creates a new collection node with the given properties and labels.
+   * Creates a new collection node with the given data.
    *
-   * Adds default values for required properties if they are not provided.
+   * While node labels and data of the collection node are mandatory, "texts" will always be an empty array
+   * (not possibility to create on collection creation process) and "annotations" can be empty as well as with items.
    *
-   * @param {ICollection} data - The data to set for the collection node.
-   * @param {string[]} nodeLabels - The additional labels to add to the collection node.
+   * @param {CollectionAccessObject} data - The data to set for the collection node.
    * @throws {NotFoundError} If the collection with the specified UUID is not found.
    * @return {Promise<ICollection>} A promise that resolves to the created collection node.
    */
-  public async createNewCollection(data: ICollection, nodeLabels: string[]): Promise<ICollection> {
+  public async createNewCollection(data: CollectionAccessObject): Promise<ICollection> {
     const guidelineService: GuidelinesService = new GuidelinesService();
+    const guidelines: IGuidelines = await guidelineService.getGuidelines();
 
-    const fields: PropertyConfig[] = await guidelineService.getCollectionConfigFields(nodeLabels);
+    const collectionFields: PropertyConfig[] =
+      guidelineService.getCollectionConfigFieldsFromGuidelines(
+        guidelines,
+        data.collection.nodeLabels,
+      );
 
-    data = { ...toNeo4jTypes(data, fields), uuid: crypto.randomUUID() } as ICollection;
+    const collection: Collection = {
+      nodeLabels: [...data.collection.nodeLabels, 'Collection'],
+      data: {
+        ...toNeo4jTypes(data.collection.data, collectionFields),
+        uuid: crypto.randomUUID(),
+      } as ICollection,
+    };
 
-    nodeLabels.push('Collection');
+    // TODO: Improve this (own type?)
+    const annotations: any = data.annotations.map(a => {
+      const annotationConfigFields: PropertyConfig[] =
+        guidelineService.getAnnotationConfigFieldsFromGuidelines(guidelines, a.properties.type);
+
+      return {
+        properties: toNeo4jTypes(a.properties, annotationConfigFields) as IAnnotation,
+        normdata: Object.values(a.normdata)
+          .flat()
+          .map(i => i.uuid),
+        additionalTexts: a.additionalTexts.map(additionalText => {
+          const collectionConfigFields: PropertyConfig[] =
+            guidelineService.getCollectionConfigFieldsFromGuidelines(
+              guidelines,
+              additionalText.collection.nodeLabels,
+            );
+
+          return {
+            collection: {
+              nodeLabels: additionalText.collection.nodeLabels,
+              data: toNeo4jTypes(
+                additionalText.collection.data,
+                collectionConfigFields,
+              ) as ICollection,
+            },
+            text: {
+              nodeLabels: additionalText.text.nodeLabels,
+              data: additionalText.text.data,
+              characters: additionalText.text.data.text.split('').map(c => {
+                return {
+                  letterLabel: additionalText.collection.data.label,
+                  text: c,
+                  uuid: crypto.randomUUID(),
+                };
+              }),
+            },
+          };
+        }),
+      };
+    });
 
     const query: string = `
-    CALL apoc.create.node($nodeLabels, $data) YIELD node as c
+    CALL apoc.create.node($collection.nodeLabels, $collection.data) YIELD node as c
+
+    CALL {
+        WITH c
+
+        UNWIND $annotations AS ann
+
+        WITH ann, c
+
+        // Create new annotation node
+        MERGE (a:Annotation {uuid: ann.properties.uuid})
+
+        // Set data
+        SET a = ann.properties
+
+        // Create edge to collection node
+        MERGE (t)-[:HAS_ANNOTATION]->(a)
+
+        // Remove edges to nodes that are not longer part of the annotation data
+        WITH ann, a, c
+
+        // Create edges to Entity nodes
+        CALL {
+            WITH ann, a
+            UNWIND ann.normdata AS createdUuid
+            MATCH (e:Entity {uuid: createdUuid})
+            MERGE (a)-[r:REFERS_TO]->(e)
+        }
+
+        // Create additional text nodes
+        CALL {
+            WITH ann, a
+            UNWIND ann.additionalTexts as textToCreate
+            
+            CREATE (a)-[:REFERS_TO]->(c:Collection)<-[:PART_OF]-(t:Text)
+
+            WITH textToCreate, a, c, t
+
+            CALL apoc.create.addLabels(c, textToCreate.collection.nodeLabels) YIELD node
+            SET c += textToCreate.collection.data
+            SET t += textToCreate.text.data
+
+            WITH textToCreate, a, c, t
+
+            CALL atag.chains.update(t.uuid, null, null, textToCreate.text.characters, {
+              textLabel: "Text",
+              elementLabel: "Character",
+              relationshipType: "NEXT_CHARACTER"
+            }) YIELD path
+
+            RETURN collect(textToCreate) as createdText
+        }
+
+        RETURN collect(a) as createdAnnotations
+    }
+
     RETURN c {.*} AS collection
     `;
 
-    const result: QueryResult = await Neo4jDriver.runQuery(query, { data, nodeLabels });
+    const result: QueryResult = await Neo4jDriver.runQuery(query, {
+      data,
+      collection,
+      annotations,
+    });
 
     return result.records[0]?.get('collection');
   }
@@ -353,6 +465,7 @@ export default class CollectionService {
    * @return {Promise<ICollection>} A promise that resolves to the deleted collection.
    */
   public async deleteCollection(uuid: string): Promise<ICollection> {
+    // TODO: Update query so that it matches the whole subgraph
     const query: string = `
     MATCH (c:Collection {uuid: $uuid})<-[:PART_OF]-(t:Text)
     OPTIONAL MATCH (t)-[:NEXT_CHARACTER*]->(chars:Character)

--- a/server/src/services/collection.service.ts
+++ b/server/src/services/collection.service.ts
@@ -389,7 +389,7 @@ export default class CollectionService {
       
       // Match subgraph
       CALL apoc.path.subgraphNodes(t, {
-          relationshipFilter: 'HAS_ANNOTATION>,REFERS_TO>,<PART_OF',
+          relationshipFilter: 'HAS_ANNOTATION>|REFERS_TO>|<PART_OF',
           labelFilter: 'Collection|Text|Annotation'
       }) YIELD node
 

--- a/server/src/services/guidelines.service.ts
+++ b/server/src/services/guidelines.service.ts
@@ -75,7 +75,7 @@ export default class GuidelinesService {
    * @param {string[]} collectionNodeLabels - The node labels of the collection.
    * @return {AnnotationType[]} The combined and deduplicated annotation types.
    */
-  public getAvailableCollectionAnnotationTypesFromGuidelines(
+  public getAvailableCollectionAnnotationConfigsFromGuidelines(
     guidelines: IGuidelines,
     collectionNodeLabels: string[],
   ): AnnotationType[] {
@@ -134,7 +134,7 @@ export default class GuidelinesService {
 
     // Properties for the given annotation type (no matter which level)
     const byAnnotationType: PropertyConfig[] =
-      this.getAvailableCollectionAnnotationTypesFromGuidelines(
+      this.getAvailableCollectionAnnotationConfigsFromGuidelines(
         guidelines,
         collectionNodeLabels,
       ).find(t => t.type === annotationType)?.properties ?? [];


### PR DESCRIPTION
Annotations nodes can now be added to Collection nodes.

Key changes:

- Added interfaces to add/remove/edit Annotations for Collections
- Updated services and cypher queries 
- Split up Annotation form component into separate, reusable components (`AnnotationFormAdditionalTextSection`, `AnnotationFormNormdataSection`, `FormPropertiesSection`)
- Added guidelines retrieval methods in backend and frontend to get annotation configs that can be added to Annotations
- Updated types (as always)

The changes are still work in progress - the guidelines retrieval methods have duplicate functionality, the types are kind of hacky etc. This will change as soon as the final guidelines structure is ready