### PR TITLE
Enable selection of Text node labels in annotation forms

### DIFF
--- a/client/src/components/AnnotationFormAdditionalTextSection.vue
+++ b/client/src/components/AnnotationFormAdditionalTextSection.vue
@@ -217,13 +217,36 @@ function togglePreviewMode(uuid: string): void {
     </template>
     <template v-for="additionalText in additionalTexts" :key="additionalText.collection.data.uuid">
       <div class="additional-text-entry">
-        <div class="additional-text-header flex justify-content-between align-items-center">
-          <span v-if="additionalText.collection.nodeLabels.length > 0" class="font-semibold">{{
-            additionalText.collection.nodeLabels
-              .map((l: string) => camelCaseToTitleCase(l))
-              .join(' | ')
-          }}</span>
-          <span v-else class="font-italic"> No label provided yet... </span>
+        <div class="button-pane flex justify-content-center">
+          <div class="label-container w-full">
+            <div class="collection-labels font-semibold">
+              <Tag
+                v-for="label in additionalText.collection.nodeLabels"
+                :value="label"
+                severity="contrast"
+                size="small"
+                class="mr-1 mb-1"
+                :pt="{
+                  root: {
+                    title: 'Collection labels',
+                  },
+                }"
+              />
+            </div>
+            <div class="text-labels font-semibold">
+              <Tag
+                v-for="label in additionalText.text.nodeLabels"
+                :value="label"
+                severity="secondary"
+                class="mr-1 mb-1"
+                :pt="{
+                  root: {
+                    title: 'Text labels',
+                  },
+                }"
+              />
+            </div>
+          </div>
           <Button
             v-if="props.mode === 'edit'"
             icon="pi pi-times"
@@ -232,7 +255,8 @@ function togglePreviewMode(uuid: string): void {
             @click="handleDeleteAdditionalText(additionalText.collection.data.uuid)"
           />
         </div>
-        <div class="flex align-items-center gap-2 overflow">
+
+        <div class="text-container flex align-items-center gap-2 overflow">
           <a
             :href="`/texts/${additionalText.text.data.uuid}`"
             title="Open text in new editor tab"
@@ -322,7 +346,7 @@ function togglePreviewMode(uuid: string): void {
             }"
           >
             <template #chip="{ value }">
-              <Tag :value="value" severity="contrast" class="mr-1" />
+              <Tag :value="value" severity="secondary" class="mr-1" />
             </template>
           </MultiSelect>
           <InputText
@@ -366,7 +390,7 @@ function togglePreviewMode(uuid: string): void {
   max-height: calc-size(auto);
 }
 
-.additional-text-header {
+.label-container {
   cursor: default;
 }
 

--- a/client/src/components/AnnotationFormAdditionalTextSection.vue
+++ b/client/src/components/AnnotationFormAdditionalTextSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { nextTick, Ref, ref, watch, useTemplateRef, ComponentPublicInstance } from 'vue';
 import { useGuidelinesStore } from '../store/guidelines';
-import { camelCaseToTitleCase, getDefaultValueForProperty } from '../utils/helper/helper';
+import { getDefaultValueForProperty } from '../utils/helper/helper';
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
 import Fieldset from 'primevue/fieldset';

--- a/client/src/components/AnnotationFormAdditionalTextSection.vue
+++ b/client/src/components/AnnotationFormAdditionalTextSection.vue
@@ -293,10 +293,14 @@ function togglePreviewMode(uuid: string): void {
             v-model="inputObject.input.collectionLabels"
             :options="inputObject.labelOptions.collection"
             display="chip"
-            placeholder="Select label"
-            size="small"
+            placeholder="Collection labels"
             class="text-center"
             :filter="false"
+            :pt="{
+              root: {
+                title: `Select Collection labels`,
+              },
+            }"
           >
             <template #chip="{ value }">
               <Tag :value="value" severity="contrast" class="mr-1" />
@@ -306,10 +310,14 @@ function togglePreviewMode(uuid: string): void {
             v-model="inputObject.input.textLabels"
             :options="inputObject.labelOptions.text"
             display="chip"
-            placeholder="Select label"
-            size="small"
+            placeholder="Text labels"
             class="text-center"
             :filter="false"
+            :pt="{
+              root: {
+                title: `Select Text labels`,
+              },
+            }"
           >
             <template #chip="{ value }">
               <Tag :value="value" severity="contrast" class="mr-1" />

--- a/client/src/components/AnnotationFormAdditionalTextSection.vue
+++ b/client/src/components/AnnotationFormAdditionalTextSection.vue
@@ -290,6 +290,7 @@ function togglePreviewMode(uuid: string): void {
       <form v-show="inputMode === 'edit'" @submit.prevent="addAdditionalText">
         <InputGroup>
           <MultiSelect
+            v-if="inputObject.labelOptions.collection.length > 0"
             v-model="inputObject.input.collectionLabels"
             :options="inputObject.labelOptions.collection"
             display="chip"
@@ -307,6 +308,7 @@ function togglePreviewMode(uuid: string): void {
             </template>
           </MultiSelect>
           <MultiSelect
+            v-if="inputObject.labelOptions.text.length > 0"
             v-model="inputObject.input.textLabels"
             :options="inputObject.labelOptions.text"
             display="chip"

--- a/client/src/components/AnnotationFormAdditionalTextSection.vue
+++ b/client/src/components/AnnotationFormAdditionalTextSection.vue
@@ -82,7 +82,15 @@ watch(
   { deep: true, immediate: true },
 );
 
-// TODO: Add JSDoc
+/**
+ * Adds a new additional text entry to the list of additional texts. The entry is based on the
+ * current input values for collection labels, text labels, and text content.
+ *
+ * After adding the entry, the input form is reset and the mode is changed to 'view'.
+ *
+ * @returns {void} This function does not return any value.
+ */
+
 function addAdditionalText(): void {
   const collectionLabels: string[] = inputObject.value.input.collectionLabels;
   const textLabels: string[] = inputObject.value.input.textLabels;

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -180,7 +180,7 @@ export function useGuidelinesStore() {
   }
 
   /**
-   * Retrieves the available labels that can be assigned to a no Text node.
+   * Retrieves the available labels that can be assigned to a a Text node.
    *
    * @return {string[]} The available labels.
    */

--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -379,7 +379,11 @@ export default class AnnotationService {
 
         WITH textToCreate, a, c, t
 
-        CALL apoc.create.addLabels(c, textToCreate.collection.nodeLabels) YIELD node
+        // Set labels
+        CALL apoc.create.addLabels(c, textToCreate.collection.nodeLabels) YIELD node AS collectionNode
+        CALL apoc.create.addLabels(t, textToCreate.text.nodeLabels) YIELD node AS textNode
+
+        // Set properties
         SET c += textToCreate.collection.data
         SET t += textToCreate.text.data
 


### PR DESCRIPTION
When adding additional texts to an annotation, users can now select labels for the to-be-created Text nodes (previously only Collection was possible).