### PR TITLE
Improve entity handling in annotation forms

### DIFF
--- a/client/src/components/AnnotationFormEntitiesSection.vue
+++ b/client/src/components/AnnotationFormEntitiesSection.vue
@@ -5,9 +5,9 @@ import { camelCaseToTitleCase } from '../utils/helper/helper';
 import AutoComplete from 'primevue/autocomplete';
 import Button from 'primevue/button';
 import Fieldset from 'primevue/fieldset';
-import Tag from 'primevue/tag';
 import { AnnotationConfigEntity, Entity } from '../models/types';
 import { useAppStore } from '../store/app';
+import EntityItem from './EntityItem.vue';
 
 /**
  *  Enriches entities item with an html key that contains the highlighted parts of the node label
@@ -150,10 +150,10 @@ function handleEntityItemSelect(item: EntityEntry, category: string): void {
 /**
  * Removes a entity item from the annotation's data.
  *
- * @param {EntityEntry} item - The entity item to be removed.
+ * @param {Entity} entity - The entity item to be removed.
  */
-function removeEntityItem(item: EntityEntry): void {
-  entities.value = entities.value.filter(entry => entry.data.uuid !== item.data.uuid);
+function handleRemoveEntity(entity: Entity): void {
+  entities.value = entities.value.filter(entry => entry.data.uuid !== entity.data.uuid);
 }
 
 /**
@@ -219,29 +219,17 @@ async function searchEntitiesOptions(searchString: string, category: string): Pr
 
     <div v-for="category in Object.keys(categorizedEntities)">
       <p class="font-bold">{{ camelCaseToTitleCase(category) }}:</p>
-      <div class="entities-entry" v-for="entry in categorizedEntities[category]">
-        <div class="button-pane flex justify-content-end">
-          <Tag
-            v-if="!props.initialEntities.map(e => e.data.uuid).includes(entry.data.uuid)"
-            size="small"
-            icon="pi pi-clock"
-            severity="warn"
-            class="mr-1"
-            title="This entity is temporary, save changes to add it to the database"
-          ></Tag>
-          <Button
-            v-if="props.mode === 'edit'"
-            icon="pi pi-times"
-            size="small"
-            severity="danger"
-            title="Remove entity"
-            @click="removeEntityItem(entry as EntityEntry)"
-          ></Button>
-        </div>
-        <span>
-          {{ entry.data.label }}
-        </span>
-      </div>
+      <EntityItem
+        v-for="entry in categorizedEntities[category]"
+        :key="entry.data.uuid"
+        :entity="entry"
+        :status="
+          props.initialEntities.map(e => e.data.uuid).includes(entry.data.uuid)
+            ? 'existing'
+            : 'temporary'
+        "
+        @remove-entity="handleRemoveEntity(entry)"
+      />
       <Button
         v-if="props.mode === 'edit'"
         v-show="entitiesSearchObject[category].mode === 'view'"
@@ -310,19 +298,6 @@ async function searchEntitiesOptions(searchString: string, category: string): Pr
 .preview.expanded {
   max-height: auto;
   max-height: calc-size(auto);
-}
-
-.entities-entry {
-  border: 1px solid gray;
-  border-radius: 5px;
-  margin-bottom: 0.5rem;
-  padding: 0.5rem;
-
-  & button {
-    width: 1rem;
-    height: 1rem;
-    padding: 10px;
-  }
 }
 
 .hidden {

--- a/client/src/components/AnnotationFormEntitiesSection.vue
+++ b/client/src/components/AnnotationFormEntitiesSection.vue
@@ -115,6 +115,17 @@ function changeEntitiesSelectionMode(category: string, mode: 'view' | 'edit'): v
 }
 
 /**
+ * Caculates the html titel attribute for the "Create new annotation" button. Takes the current input
+ * of the autocomplete and a generic message.
+ *
+ * @param {string} currentUserInput - Takes the current input of the autocomplete
+ * @returns {string} The html title attribute string for the button.
+ */
+function getHtmlTitleForButton(currentUserInput: string): string {
+  return `Add new entity with label "${currentUserInput}" to annotation`;
+}
+
+/**
  * Creates a new entity item based on the given label and adds it to the given category.
  *
  * @param {string} newLabel - The label of the new entity item
@@ -270,17 +281,21 @@ async function searchEntitiesOptions(searchString: string, category: string): Pr
         </template>
         <template #empty>
           <div class="font-italic text-center mb-1">No results found</div>
-          <Button
-            icon="pi pi-plus"
-            class="w-full"
-            size="small"
-            label="Create new entity"
-            severity="secondary"
-            title="Add new entity to annotation"
-            @click="
-              handleCreateNewEntity(entitiesSearchObject[category].elm[0].inputValue, category)
-            "
-          ></Button>
+        </template>
+        <template #footer>
+          <div class="w p-2">
+            <Button
+              icon="pi pi-plus"
+              class="w-full"
+              size="small"
+              label="Create new entity"
+              severity="secondary"
+              :title="getHtmlTitleForButton(entitiesSearchObject[category].elm[0].inputValue)"
+              @click="
+                handleCreateNewEntity(entitiesSearchObject[category].elm[0].inputValue, category)
+              "
+            />
+          </div>
         </template>
       </AutoComplete>
     </div>

--- a/client/src/components/AnnotationFormEntitiesSection.vue
+++ b/client/src/components/AnnotationFormEntitiesSection.vue
@@ -5,6 +5,7 @@ import { camelCaseToTitleCase } from '../utils/helper/helper';
 import AutoComplete from 'primevue/autocomplete';
 import Button from 'primevue/button';
 import Fieldset from 'primevue/fieldset';
+import Tag from 'primevue/tag';
 import { AnnotationConfigEntity, Entity } from '../models/types';
 import { useAppStore } from '../store/app';
 
@@ -46,6 +47,7 @@ const categorizedEntities = computed<Record<string, Entity[]>>(() => {
 const props = defineProps<{
   mode?: 'edit' | 'view';
   defaultSearchValue?: string;
+  initialEntities: Entity[];
 }>();
 
 const entitiesAreCollapsed = ref<boolean>(false);
@@ -217,21 +219,28 @@ async function searchEntitiesOptions(searchString: string, category: string): Pr
 
     <div v-for="category in Object.keys(categorizedEntities)">
       <p class="font-bold">{{ camelCaseToTitleCase(category) }}:</p>
-      <div
-        class="entities-entry flex justify-content-between align-items-center"
-        v-for="entry in categorizedEntities[category]"
-      >
+      <div class="entities-entry" v-for="entry in categorizedEntities[category]">
+        <div class="button-pane flex justify-content-end">
+          <Tag
+            v-if="!props.initialEntities.map(e => e.data.uuid).includes(entry.data.uuid)"
+            size="small"
+            icon="pi pi-clock"
+            severity="warn"
+            class="mr-1"
+            title="This entity is temporary, save changes to add it to the database"
+          ></Tag>
+          <Button
+            v-if="props.mode === 'edit'"
+            icon="pi pi-times"
+            size="small"
+            severity="danger"
+            title="Remove entity"
+            @click="removeEntityItem(entry as EntityEntry)"
+          ></Button>
+        </div>
         <span>
           {{ entry.data.label }}
         </span>
-        <Button
-          v-if="props.mode === 'edit'"
-          icon="pi pi-times"
-          size="small"
-          severity="danger"
-          title="Remove entity"
-          @click="removeEntityItem(entry as EntityEntry)"
-        ></Button>
       </div>
       <Button
         v-if="props.mode === 'edit'"

--- a/client/src/components/CollectionEditPane.vue
+++ b/client/src/components/CollectionEditPane.vue
@@ -690,6 +690,11 @@ function toggleViewMode(direction: TabView): void {
               "
               :mode="formMode"
               v-model="annotation.entities"
+              :initialEntities="
+                initialTemporaryWorkData.annotations.find(
+                  a => a.properties.uuid === annotation.properties.uuid,
+                ).entities ?? []
+              "
             />
             <div class="action-buttons flex justify-content-center">
               <Button

--- a/client/src/components/EditorAnnotationForm.vue
+++ b/client/src/components/EditorAnnotationForm.vue
@@ -166,6 +166,7 @@ function handleShrink(): void {
       v-model="annotation.data.entities"
       mode="edit"
       :default-search-value="annotation.data.properties.text"
+      :initialEntities="annotation.initialData.entities"
     />
 
     <div v-if="!panelIsCollapsed" class="edit-buttons flex justify-content-center">

--- a/client/src/components/EntityItem.vue
+++ b/client/src/components/EntityItem.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+import { Entity } from '../models/types';
+import Button from 'primevue/button';
+import { Popover } from 'primevue';
+import Tag from 'primevue/tag';
+import DataTable from 'primevue/datatable';
+import Column from 'primevue/column';
+import { capitalize, useTemplateRef } from 'vue';
+
+const props = defineProps<{
+  status: 'existing' | 'temporary';
+  entity: Entity;
+}>();
+
+const emit = defineEmits<{
+  (e: 'removeEntity', entity: Entity): void;
+}>();
+
+const infoIcon = useTemplateRef('info-icon');
+
+function handleRemoveEntity() {
+  emit('removeEntity', props.entity);
+}
+
+function togglePopover(event: MouseEvent): void {
+  infoIcon.value.toggle(event);
+}
+
+const tableData = Object.entries(props.entity.data).map(([property, value]) => {
+  return { property, value };
+});
+</script>
+
+<template>
+  <div class="entities-entry">
+    <div class="button-pane flex justify-content-end">
+      <Tag
+        v-if="props.status === 'temporary'"
+        size="small"
+        icon="pi pi-clock"
+        severity="warn"
+        class="mr-1"
+        title="This entity is temporary, save changes to add it to the database"
+      ></Tag>
+      <Button
+        icon="pi pi-times"
+        size="small"
+        severity="danger"
+        title="Remove entity"
+        @click="handleRemoveEntity"
+      ></Button>
+    </div>
+    <span>
+      {{ props.entity.data.label }}
+    </span>
+    <span
+      class="pi pi-info-circle ml-2 cursor-pointer"
+      @mouseenter="togglePopover"
+      @mouseleave="togglePopover"
+    ></span>
+
+    <Popover
+      ref="info-icon"
+      :pt="{
+        root: {
+          class: 'w-25rem',
+          style: {
+            zIndex: 'var(--z-index-max)',
+          },
+        },
+      }"
+    >
+      <DataTable
+        :value="tableData"
+        scrollable
+        scrollHeight="flex"
+        resizableColumns
+        rowHover
+        tableStyle="table-layout: fixed;"
+        size="small"
+      >
+        <Column field="property" header="Property">
+          <template #body="{ data }">
+            <span>{{ capitalize(data['property']) }}</span>
+          </template>
+        </Column>
+        <Column field="value" header="Value">
+          <template #body="{ data }">
+            <span style="white-space: normal">{{ data['value'] }}</span>
+          </template>
+        </Column>
+      </DataTable>
+    </Popover>
+  </div>
+</template>
+
+<style scoped>
+.entities-entry {
+  border: 1px solid gray;
+  border-radius: 5px;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+
+  & button {
+    width: 1rem;
+    height: 1rem;
+    padding: 10px;
+  }
+}
+</style>

--- a/client/src/components/EntityItem.vue
+++ b/client/src/components/EntityItem.vue
@@ -53,11 +53,14 @@ const tableData = Object.entries(props.entity.data).map(([property, value]) => {
     <span>
       {{ props.entity.data.label }}
     </span>
-    <span
-      class="pi pi-info-circle ml-2 cursor-pointer"
-      @mouseenter="togglePopover"
-      @mouseleave="togglePopover"
-    ></span>
+    <Button
+      icon="pi pi-info-circle"
+      size="small"
+      severity="secondary"
+      class="ml-2"
+      title="Click to show preview of entity data"
+      @click="togglePopover"
+    ></Button>
 
     <Popover
       ref="info-icon"


### PR DESCRIPTION
The index entries for entities in annotation forms now contain more information.

Key changes:
- Created separate `EntityItem.vue` component
- Added flag when entites are only in working copy and are not saved yet
- Always show "Create new entity" button event when the autocomplete has results
- Show complete entity node data when clicking on "details" button