### PR TITLE
Refactor handling of additional texts in annotation forms

### DIFF
--- a/client/src/components/AnnotationFormAdditionalTextSection.vue
+++ b/client/src/components/AnnotationFormAdditionalTextSection.vue
@@ -189,7 +189,7 @@ function togglePreviewMode(uuid: string): void {
     <template v-for="additionalText in additionalTexts" :key="additionalText.annotation.uuid">
       <div class="additional-text-entry">
         <div class="button-pane flex justify-content-center mb-2">
-          <div class="annotation-type-tag-container w-full">
+          <div class="annotation-type-tag-container flex justify-content-start w-full">
             <NodeTag type="Collection" :content="additionalText.annotation.type" />
           </div>
           <div class="flex">

--- a/client/src/components/AnnotationFormAdditionalTextSection.vue
+++ b/client/src/components/AnnotationFormAdditionalTextSection.vue
@@ -1,29 +1,24 @@
 <script setup lang="ts">
 import { nextTick, Ref, ref, watch, useTemplateRef, ComponentPublicInstance } from 'vue';
 import { useGuidelinesStore } from '../store/guidelines';
-import { getDefaultValueForProperty } from '../utils/helper/helper';
 import Button from 'primevue/button';
 import InputText from 'primevue/inputtext';
 import Fieldset from 'primevue/fieldset';
-import Message from 'primevue/message';
-import { MultiSelect } from 'primevue';
-import { AdditionalText, PropertyConfig } from '../models/types';
+import Select from 'primevue/select';
+import { AdditionalText } from '../models/types';
 import InputGroup from 'primevue/inputgroup';
-import ICollection from '../models/ICollection';
 import IText from '../models/IText';
 import NodeTag from './NodeTag.vue';
+import IAnnotation from '../models/IAnnotation';
+import Tag from 'primevue/tag';
 
 /**
  * Interface for relevant state information about additional texts of the annotation
  */
 interface InputObject {
-  labelOptions: {
-    collection: string[];
-    text: string[];
-  };
+  annotationTypeOptions: string[];
   input: {
-    collectionLabels: string[];
-    textLabels: string[];
+    annotationType: string;
     text: string;
   };
 }
@@ -35,17 +30,13 @@ const props = defineProps<{
   mode?: 'edit' | 'view';
 }>();
 
-const { guidelines, getAvailableTextLabels, getCollectionConfigFields } = useGuidelinesStore();
+const { guidelines } = useGuidelinesStore();
 
 const sectionIsCollapsed = ref<boolean>(false);
 const inputObject: Ref<InputObject> = ref<InputObject>({
-  labelOptions: {
-    collection: guidelines.value.annotations.additionalTexts,
-    text: getAvailableTextLabels(),
-  },
+  annotationTypeOptions: guidelines.value.annotations.additionalTexts,
   input: {
-    collectionLabels: [],
-    textLabels: [],
+    annotationType: guidelines.value.annotations.additionalTexts[0] ?? null,
     text: '',
   },
 });
@@ -61,20 +52,16 @@ watch(
   (newTexts, oldTexts) => {
     // Add new text if it doesn't already exist
     newTexts.value.forEach(text => {
-      if (!textPreviewHandler.value.has(text.collection.data.uuid)) {
-        textPreviewHandler.value.set(text.collection.data.uuid, 'collapsed');
+      if (!textPreviewHandler.value.has(text.annotation.uuid)) {
+        textPreviewHandler.value.set(text.annotation.uuid, 'collapsed');
       }
     });
 
     // Remove texts that no longer exist
     if (oldTexts) {
       oldTexts.value.forEach(text => {
-        if (
-          !newTexts.value.some(
-            newText => newText.collection.data.uuid === text.collection.data.uuid,
-          )
-        ) {
-          textPreviewHandler.value.delete(text.collection.data.uuid);
+        if (!newTexts.value.some(newText => newText.annotation.uuid === text.annotation.uuid)) {
+          textPreviewHandler.value.delete(text.annotation.uuid);
         }
       });
     }
@@ -84,7 +71,7 @@ watch(
 
 /**
  * Adds a new additional text entry to the list of additional texts. The entry is based on the
- * current input values for collection labels, text labels, and text content.
+ * current input values for annotation type and text content.
  *
  * After adding the entry, the input form is reset and the mode is changed to 'view'.
  *
@@ -92,28 +79,15 @@ watch(
  */
 
 function addAdditionalText(): void {
-  const collectionLabels: string[] = inputObject.value.input.collectionLabels;
-  const textLabels: string[] = inputObject.value.input.textLabels;
-  const defaultCollectionFields: PropertyConfig[] = getCollectionConfigFields(collectionLabels);
-  const newCollectionProperties: ICollection = {} as ICollection;
-
-  defaultCollectionFields.forEach((field: PropertyConfig) => {
-    newCollectionProperties[field.name] =
-      field?.required === true ? getDefaultValueForProperty(field.type) : null;
-  });
+  const annotationType: string = inputObject.value.input.annotationType;
 
   additionalTexts.value.push({
-    collection: {
-      nodeLabels: collectionLabels,
-      data: {
-        ...newCollectionProperties,
-        uuid: crypto.randomUUID(),
-        // Create empty label property (is required, but should not contain any default data)
-        label: '',
-      } as ICollection,
-    },
+    annotation: {
+      type: annotationType ?? 'commentary',
+      uuid: crypto.randomUUID(),
+    } as IAnnotation,
     text: {
-      nodeLabels: textLabels,
+      nodeLabels: [],
       data: {
         uuid: crypto.randomUUID(),
         text: inputObject.value.input.text,
@@ -168,13 +142,11 @@ function finishInputOperation(): void {
 /**
  * Deletes an additional text entry from the list of additional texts of the annotation.
  *
- * @param {string} collectionUuid - The UUID of the collection of the additional text to be deleted.
+ * @param {string} annotationUuid - The UUID of the annotation of the additional text to be deleted.
  * @returns {void} This function does not return any value.
  */
-function handleDeleteAdditionalText(collectionUuid: string): void {
-  additionalTexts.value = additionalTexts.value.filter(
-    t => t.collection.data.uuid !== collectionUuid,
-  );
+function handleDeleteAdditionalText(annotationUuid: string): void {
+  additionalTexts.value = additionalTexts.value.filter(t => t.annotation.uuid !== annotationUuid);
 }
 
 /**
@@ -185,8 +157,7 @@ function handleDeleteAdditionalText(collectionUuid: string): void {
  */
 function resetInputForm(): void {
   inputObject.value.input = {
-    collectionLabels: [],
-    textLabels: [],
+    annotationType: null,
     text: '',
   };
 }
@@ -215,36 +186,35 @@ function togglePreviewMode(uuid: string): void {
     <template #toggleicon>
       <span :class="`pi pi-chevron-${sectionIsCollapsed ? 'down' : 'up'}`"></span>
     </template>
-    <template v-for="additionalText in additionalTexts" :key="additionalText.collection.data.uuid">
+    <template v-for="additionalText in additionalTexts" :key="additionalText.annotation.uuid">
       <div class="additional-text-entry">
-        <div class="button-pane flex justify-content-center">
-          <div class="label-container w-full">
-            <div class="collection-labels font-semibold">
-              <NodeTag
-                v-for="label in additionalText.collection.nodeLabels"
-                type="Collection"
-                :content="label"
-                class="mr-1 mb-4"
-              />
-            </div>
-            <div class="text-labels font-semibold">
-              <NodeTag
-                v-for="label in additionalText.text.nodeLabels"
-                :content="label"
-                type="Text"
-                class="mr-1 mb-1"
-              />
-            </div>
+        <div class="button-pane flex justify-content-center mb-2">
+          <div class="annotation-type-tag-container w-full">
+            <NodeTag type="Collection" :content="additionalText.annotation.type" />
           </div>
-          <Button
-            v-if="props.mode === 'edit'"
-            icon="pi pi-times"
-            severity="danger"
-            title="Remove this text from annotation"
-            @click="handleDeleteAdditionalText(additionalText.collection.data.uuid)"
-          />
+          <div class="flex">
+            <Tag
+              v-if="
+                !props.initialAdditionalTexts
+                  .map(t => t.annotation.uuid)
+                  .includes(additionalText.annotation.uuid)
+              "
+              size="small"
+              icon="pi pi-clock"
+              severity="warn"
+              class="mr-1"
+              :style="{ height: '1rem', padding: '10px' }"
+              title="This additional text is temporary, save changes to add it to the database"
+            ></Tag>
+            <Button
+              v-if="props.mode === 'edit'"
+              icon="pi pi-times"
+              severity="danger"
+              title="Remove this text from annotation"
+              @click="handleDeleteAdditionalText(additionalText.annotation.uuid)"
+            />
+          </div>
         </div>
-
         <div class="text-container flex align-items-center gap-2 overflow">
           <a
             :href="`/texts/${additionalText.text.data.uuid}`"
@@ -252,7 +222,7 @@ function togglePreviewMode(uuid: string): void {
             class="flex align-items-center gap-1"
             target="_blank"
           >
-            <div :class="`preview ${textPreviewHandler.get(additionalText.collection.data.uuid)}`">
+            <div :class="`preview ${textPreviewHandler.get(additionalText.annotation.uuid)}`">
               {{ additionalText.text.data.text }}
             </div>
             <i class="pi pi-external-link"></i>
@@ -260,7 +230,7 @@ function togglePreviewMode(uuid: string): void {
         </div>
         <Button
           :icon="
-            textPreviewHandler.get(additionalText.collection.data.uuid) === 'collapsed'
+            textPreviewHandler.get(additionalText.annotation.uuid) === 'collapsed'
               ? 'pi pi-angle-double-down'
               : 'pi pi-angle-double-up'
           "
@@ -268,22 +238,12 @@ function togglePreviewMode(uuid: string): void {
           size="small"
           class="w-full"
           :title="
-            textPreviewHandler.get(additionalText.collection.data.uuid) === 'collapsed'
+            textPreviewHandler.get(additionalText.annotation.uuid) === 'collapsed'
               ? 'Show full text'
               : 'Hide full text'
           "
-          @click="togglePreviewMode(additionalText.collection.data.uuid)"
+          @click="togglePreviewMode(additionalText.annotation.uuid)"
         />
-        <Message
-          v-if="
-            !props.initialAdditionalTexts
-              .map(t => t.collection.data.uuid)
-              .includes(additionalText.collection.data.uuid)
-          "
-          severity="warn"
-        >
-          Save changes to edit new text...
-        </Message>
       </div>
 
       <hr />
@@ -302,42 +262,21 @@ function togglePreviewMode(uuid: string): void {
       />
       <form v-show="inputMode === 'edit'" @submit.prevent="addAdditionalText">
         <InputGroup>
-          <MultiSelect
-            v-if="inputObject.labelOptions.collection.length > 0"
-            v-model="inputObject.input.collectionLabels"
-            :options="inputObject.labelOptions.collection"
+          <Select
+            v-if="inputObject.annotationTypeOptions.length > 0"
+            v-model="inputObject.input.annotationType"
+            :options="inputObject.annotationTypeOptions"
             display="chip"
-            placeholder="Collection labels"
+            required
+            placeholder="Annotation type"
             class="text-center"
             :filter="false"
             :pt="{
               root: {
-                title: `Select Collection labels`,
+                title: `Select Annotation type`,
               },
             }"
-          >
-            <template #chip="{ value }">
-              <NodeTag type="Collection" :content="value" class="mr-1" />
-            </template>
-          </MultiSelect>
-          <MultiSelect
-            v-if="inputObject.labelOptions.text.length > 0"
-            v-model="inputObject.input.textLabels"
-            :options="inputObject.labelOptions.text"
-            display="chip"
-            placeholder="Text labels"
-            class="text-center"
-            :filter="false"
-            :pt="{
-              root: {
-                title: `Select Text labels`,
-              },
-            }"
-          >
-            <template #chip="{ value }">
-              <NodeTag type="Text" :content="value" class="mr-1" />
-            </template>
-          </MultiSelect>
+          />
           <InputText
             ref="additional-text-input"
             required
@@ -379,7 +318,7 @@ function togglePreviewMode(uuid: string): void {
   max-height: calc-size(auto);
 }
 
-.label-container {
+.annotation-type-tag-container {
   cursor: default;
 }
 

--- a/client/src/components/CollectionEditPane.vue
+++ b/client/src/components/CollectionEditPane.vue
@@ -699,7 +699,7 @@ function toggleViewMode(direction: TabView): void {
               :initialEntities="
                 initialTemporaryWorkData.annotations.find(
                   a => a.properties.uuid === annotation.properties.uuid,
-                ).entities ?? []
+                )?.entities ?? []
               "
             />
             <div class="action-buttons flex justify-content-center">

--- a/client/src/components/EditorHeader.vue
+++ b/client/src/components/EditorHeader.vue
@@ -17,8 +17,8 @@ const { bookmarks, toggleBookmark } = useBookmarks();
 
 const breadcrumbRoot = ref<MenuItem>({
   role: 'Collection',
-  label: correspondingCollection.value.data.label,
-  uuid: correspondingCollection.value.data.uuid,
+  label: correspondingCollection.value?.data.label,
+  uuid: correspondingCollection.value?.data.uuid,
 });
 const breadcrumbItems = ref<MenuItem[]>([{ role: 'Text', labels: text.value.nodeLabels }]);
 

--- a/client/src/components/EditorMetadata.vue
+++ b/client/src/components/EditorMetadata.vue
@@ -22,9 +22,13 @@ const { getCollectionConfigFields } = useGuidelinesStore();
 
 const tableData: CollectionTableEntry[] = getCollectionTableData();
 
-function getCollectionTableData() {
+function getCollectionTableData(): CollectionTableEntry[] | null {
+  if (!correspondingCollection.value) {
+    return null;
+  }
+
   const fields: PropertyConfig[] = getCollectionConfigFields(
-    correspondingCollection.value.nodeLabels as string[],
+    correspondingCollection.value?.nodeLabels as string[],
   );
 
   return fields.map(field => ({
@@ -83,7 +87,7 @@ async function handleCopy(): Promise<void> {
           <NodeTag :content="label" type="Text" class="mr-1" />
         </div>
         <div v-else>
-          <i
+          <i v-if="correspondingCollection"
             >This text has no labels yet. To add some, go to the
             <RouterLink :to="`/collections/${correspondingCollection.data.uuid}`"
               >Collection page.<i class="pi pi-external-link ml-2"></i></RouterLink
@@ -134,7 +138,7 @@ async function handleCopy(): Promise<void> {
       </template>
     </Fieldset>
 
-    <Fieldset legend="Collection" toggleable>
+    <Fieldset legend="Collection" toggleable v-if="tableData">
       <template #toggleicon="{ collapsed }">
         <span :class="`pi pi-chevron-${collapsed ? 'down' : 'up'}`"></span>
       </template>

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -260,7 +260,7 @@ export type StandoffJson = {
 export type Text = Node<IText>;
 
 export type TextAccessObject = {
-  collection: Collection;
+  collection: Collection | null;
   paths: NodeAncestry[];
   text: Text;
 };

--- a/client/src/models/types.ts
+++ b/client/src/models/types.ts
@@ -5,7 +5,7 @@ import IEntity from './IEntity';
 import IText from './IText';
 
 export type AdditionalText = {
-  collection: Collection;
+  annotation: IAnnotation;
   text: Text;
 };
 

--- a/client/src/store/editor.ts
+++ b/client/src/store/editor.ts
@@ -394,11 +394,11 @@ export function useEditorStore() {
       const initialEntityUuids: Set<string> = new Set(a.initialData.entities.map(m => m.data.uuid));
 
       const initialAdditionalTextUuids: Set<string> = new Set(
-        a.initialData.additionalTexts.map(at => at.collection.data.uuid),
+        a.initialData.additionalTexts.map(at => at.annotation.uuid),
       );
 
       const additionalTextUuids: Set<string> = new Set(
-        a.data.additionalTexts.map(at => at.collection.data.uuid),
+        a.data.additionalTexts.map(at => at.annotation.uuid),
       );
 
       if (

--- a/guidelines.development.json
+++ b/guidelines.development.json
@@ -70,16 +70,6 @@
         }
       },
       {
-        "additionalLabel": "Comment",
-        "level": "secondary",
-        "properties": []
-      },
-      {
-        "additionalLabel": "CommentInternal",
-        "level": "secondary",
-        "properties": []
-      },
-      {
         "additionalLabel": "Manuscript",
         "level": "secondary",
         "properties": []
@@ -454,6 +444,6 @@
         "nodeLabel": "LiteratureTitle"
       }
     ],
-    "additionalTexts": ["Comment", "CommentInternal"]
+    "additionalTexts": ["commentary"]
   }
 }

--- a/guidelines.hildegard.json
+++ b/guidelines.hildegard.json
@@ -70,16 +70,6 @@
         }
       },
       {
-        "additionalLabel": "Comment",
-        "level": "secondary",
-        "properties": []
-      },
-      {
-        "additionalLabel": "CommentInternal",
-        "level": "secondary",
-        "properties": []
-      },
-      {
         "additionalLabel": "Manuscript",
         "level": "secondary",
         "properties": []
@@ -454,6 +444,6 @@
         "nodeLabel": "LiteratureTitle"
       }
     ],
-    "additionalTexts": ["Comment", "CommentInternal"]
+    "additionalTexts": ["commentary"]
   }
 }

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -193,7 +193,7 @@ export type StandoffJson = {
 export type Text = Node<IText>;
 
 export type TextAccessObject = {
-  collection: Collection;
+  collection: Collection | null;
   paths: NodeAncestry[];
   text: Text;
 };

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -5,7 +5,7 @@ import IEntity from './IEntity.js';
 import IText from './IText.js';
 
 export type AdditionalText = {
-  collection: Collection;
+  annotation: IAnnotation;
   text: Text;
 };
 

--- a/server/src/services/annotation.service.ts
+++ b/server/src/services/annotation.service.ts
@@ -14,7 +14,6 @@ import {
 } from '../models/types.js';
 import { IGuidelines } from '../models/IGuidelines.js';
 import ICharacter from '../models/ICharacter.js';
-import ICollection from '../models/ICollection.js';
 
 /**
  * Data type for annotation data before saving them in the database. Contains only the
@@ -124,16 +123,14 @@ export default class AnnotationService {
 
     WITH a, entities AS entities
 
+    // Fetch additional texts
     CALL {
         WITH a
 
-        MATCH (a)-[r:REFERS_TO]->(x:Collection)<-[:PART_OF]-(t2:Text)
+        MATCH (a)-[r:HAS_ANNOTATION]->(aComment:Annotation)-[:REFERS_TO]->(t2:Text)
 
         RETURN collect({
-            collection: {
-                nodeLabels: [l IN labels(x) WHERE l <> 'Collection' | l],
-                data: x {.*}
-            }, 
+            annotation: aComment {.*}, 
             text: {
                 nodeLabels: [l IN labels(t2) WHERE l <> 'Text' | l],
                 data: t2 {.*}
@@ -207,30 +204,15 @@ export default class AnnotationService {
       const deletedAdditionalTexts: AdditionalText[] = [];
 
       const oldTextUuids: string[] = annotation.initialData!.additionalTexts.map(
-        t => t.collection.data.uuid,
+        t => t.annotation.uuid,
       );
-      const newTextUuids: string[] = annotation.data!.additionalTexts.map(
-        t => t.collection.data.uuid,
-      );
+      const newTextUuids: string[] = annotation.data!.additionalTexts.map(t => t.annotation.uuid);
 
       // Characters need to be created to be saved in the query
       annotation.data!.additionalTexts.forEach(additionalText => {
-        if (!oldTextUuids.includes(additionalText.collection.data.uuid)) {
-          // Done here because collection field configuration may be different for each additional text
-          const collectionConfigFields: PropertyConfig[] =
-            guidelineService.getCollectionConfigFieldsFromGuidelines(
-              guidelines,
-              additionalText.collection.nodeLabels,
-            );
-
+        if (!oldTextUuids.includes(additionalText.annotation.uuid)) {
           createdAdditionalTexts.push({
-            collection: {
-              nodeLabels: additionalText.collection.nodeLabels,
-              data: toNeo4jTypes(
-                additionalText.collection.data,
-                collectionConfigFields,
-              ) as ICollection,
-            },
+            annotation: additionalText.annotation,
             text: {
               nodeLabels: additionalText.text.nodeLabels,
               data: additionalText.text.data,
@@ -241,7 +223,7 @@ export default class AnnotationService {
       });
 
       annotation.initialData!.additionalTexts.forEach(additionalText => {
-        if (!newTextUuids.includes(additionalText.collection.data.uuid)) {
+        if (!newTextUuids.includes(additionalText.annotation.uuid)) {
           deletedAdditionalTexts.push(additionalText);
         }
       });
@@ -282,7 +264,7 @@ export default class AnnotationService {
         WHERE delAnnotation.status = 'deleted'
         MATCH (a:Annotation {uuid: delAnnotation.data.properties.uuid})
 
-        // Delete only Annotation node - additional texts (Collection-Text) are kept for now
+        // Delete only Annotation node - additional texts (Annotation-Text) are kept for now
         DETACH DELETE a
     }
 
@@ -329,10 +311,10 @@ export default class AnnotationService {
         WITH ann, a
         UNWIND ann.data.additionalTexts.deleted as textToDelete
 
-        // Match Collection node that is the entry point into subgraph
-        OPTIONAL MATCH (a)-[r:REFERS_TO]->(c:Collection {uuid: textToDelete.collection.data.uuid})
+        // Match Annotation node that is the entry point into subgraph
+        OPTIONAL MATCH (a)-[r:HAS_ANNOTATION]->(:Annotation {uuid: textToDelete.annotation.uuid})
 
-        // Detach Collection node, but keep it in the database for now.
+        // Detach Annotation node, but keep it in the database for now.
         DELETE r
     }
 
@@ -341,19 +323,15 @@ export default class AnnotationService {
         WITH ann, a
         UNWIND ann.data.additionalTexts.created as textToCreate
         
-        CREATE (a)-[:REFERS_TO]->(c:Collection)<-[:PART_OF]-(t:Text)
+        CREATE (a)-[:HAS_ANNOTATION]->(aCommentary:Annotation)-[:REFERS_TO]->(t:Text)
 
-        WITH textToCreate, a, c, t
-
-        // Set labels
-        CALL apoc.create.addLabels(c, textToCreate.collection.nodeLabels) YIELD node AS collectionNode
-        CALL apoc.create.addLabels(t, textToCreate.text.nodeLabels) YIELD node AS textNode
+        WITH textToCreate, a, aCommentary, t
 
         // Set properties
-        SET c += textToCreate.collection.data
+        SET aCommentary += textToCreate.annotation
         SET t += textToCreate.text.data
 
-        WITH textToCreate, a, c, t
+        WITH textToCreate, a, aCommentary, t
 
         CALL atag.chains.update(t.uuid, null, null, textToCreate.text.characters, {
           textLabel: "Text",

--- a/server/src/services/text.service.ts
+++ b/server/src/services/text.service.ts
@@ -48,7 +48,7 @@ export default class TextService {
   public async getExtendedTextByUuid(uuid: string): Promise<TextAccessObject> {
     const query: string = `
     MATCH (t:Text {uuid: $uuid})
-    MATCH (t)-[:PART_OF]->(c:Collection)
+    OPTIONAL MATCH (t)-[:PART_OF]->(c:Collection)
     
     CALL (t) {
         ${ancestryPaths('t')}
@@ -59,10 +59,13 @@ export default class TextService {
             nodeLabels: [l IN labels(t) WHERE l <> 'Text' | l],
             data: t {.*}
         },
-        collection: {
-            nodeLabels: [l IN labels(c) WHERE l <> 'Collection' | l],
-            data: c {.*}
-        },
+        collection: CASE 
+                        WHEN c IS NULL THEN null 
+                        ELSE {
+                            nodeLabels: [l IN labels(c) WHERE l <> 'Collection' | l],
+                            data: c {.*}
+                        }
+                    END,
         paths: paths
     } as text
     `;


### PR DESCRIPTION
Additional texts (comments, notes etc.) which are connected to annotations are now stored as Annotation nodes instead of Collection nodes.

Key changes:
- Refactored annotation forms in frontend
- Updated guidelines for hildegard (added `commentary` as type for additional text annotations)
- Changed backend service for retrieving/updating annotations
- Made parent collections for Text nodes (via `PART_OF` relationship) optional