### PR TITLE
Show modals when annotations are created

### DIFF
--- a/client/src/components/AnnotationCreateModal.vue
+++ b/client/src/components/AnnotationCreateModal.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import { computed, inject, onMounted, ref, toRef, watch } from 'vue';
+import Button from 'primevue/button';
+import { useAppStore } from '../store/app';
+import { useRoute } from 'vue-router';
+import Fieldset from 'primevue/fieldset';
+import FormPropertiesSection from './FormPropertiesSection.vue';
+import AnnotationFormAdditionalTextSection from './AnnotationFormAdditionalTextSection.vue';
+import AnnotationFormEntitiesSection from './AnnotationFormEntitiesSection.vue';
+import { Annotation, AnnotationType, PropertyConfig } from '../models/types';
+import { useGuidelinesStore } from '../store/guidelines';
+
+const route = useRoute();
+const dialogRef: any = inject('dialogRef');
+
+const emit = defineEmits<{
+  (e: 'close'): void;
+  (e: 'created'): void;
+}>();
+
+const { addToastMessage } = useAppStore();
+const { getAnnotationConfig, getAnnotationFields } = useGuidelinesStore();
+
+const annotationToCreate: Annotation = dialogRef.value.data.annotation;
+const config: AnnotationType = getAnnotationConfig(annotationToCreate.data.properties.type);
+const propertyFields: PropertyConfig[] = getAnnotationFields(
+  annotationToCreate.data.properties.type,
+);
+
+const asyncOperationRunning = ref<boolean>(false);
+const propertiesAreCollapsed = ref<boolean>(false);
+
+watch(() => route.path, closeModal);
+
+// function closeModal(): void {
+//   emit('close');
+// }
+
+function closeModal(): void {
+  dialogRef.value.close();
+}
+
+// function showMessage(result: 'success' | 'error', error?: Error) {
+//   addToastMessage({
+//     severity: result,
+//     summary: result === 'success' ? 'Changes saved successfully' : 'Error saving changes',
+//     detail: error?.message ?? '',
+//     life: 2000,
+//   });
+// }
+// const isMounted = computed(() => {
+//   if (annotationToCreate.value !== null) {
+//     console.log('exists');
+//     return true;
+//   } else {
+//     console.log('DOJES NOT EXIST');
+//     return false;
+//   }
+// });
+
+function handleCancelClick(): void {
+  closeModal();
+}
+
+async function handleSubmitClick(): Promise<void> {
+  asyncOperationRunning.value = true;
+
+  try {
+    // await api.deleteCollection(collection.value.collection.data.uuid);
+
+    closeModal();
+
+    emit('created');
+  } catch (error: unknown) {
+    // showMessage('error', error as Error);
+  } finally {
+    asyncOperationRunning.value = false;
+  }
+}
+</script>
+
+<template>
+  <h2 class="w-full text-center m-0">
+    Create new
+    <span class="font-italic">{{ annotationToCreate.data.properties.type }}</span> Annotation
+  </h2>
+
+  <div class="content text-center mb-2" v-if="annotationToCreate">
+    <Fieldset
+      legend="Properties"
+      :toggle-button-props="{
+        title: `${propertiesAreCollapsed ? 'Expand' : 'Collapse'} properties`,
+      }"
+      :toggleable="true"
+      @toggle="propertiesAreCollapsed = !propertiesAreCollapsed"
+    >
+      <template #toggleicon>
+        <span :class="`pi pi-chevron-${propertiesAreCollapsed ? 'down' : 'up'}`"></span>
+      </template>
+      <FormPropertiesSection
+        v-model="annotationToCreate.data.properties"
+        :fields="propertyFields"
+        mode="edit"
+      />
+    </Fieldset>
+    <AnnotationFormAdditionalTextSection
+      v-if="config.hasAdditionalTexts === true"
+      v-model="annotationToCreate.data.additionalTexts"
+      :initial-additional-texts="annotationToCreate.initialData.additionalTexts"
+      mode="edit"
+    />
+    <AnnotationFormEntitiesSection
+      v-if="config.hasEntities === true"
+      v-model="annotationToCreate.data.entities"
+      mode="edit"
+      :annotation-config="config"
+      :default-search-value="annotationToCreate.data.properties.text"
+      :initialEntities="annotationToCreate.initialData.entities"
+    />
+  </div>
+
+  <div class="button-container flex justify-content-end gap-2">
+    <Button
+      type="submit"
+      label="Create"
+      severity="success"
+      :loading="asyncOperationRunning"
+      @click="handleSubmitClick"
+    ></Button>
+    <Button
+      type="button"
+      label="Cancel"
+      title="Cancel"
+      severity="secondary"
+      @click="handleCancelClick"
+    ></Button>
+  </div>
+</template>
+
+<style scoped></style>

--- a/client/src/components/AnnotationCreateModal.vue
+++ b/client/src/components/AnnotationCreateModal.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed, inject, onMounted, ref, toRef, watch } from 'vue';
+import { computed, inject, ref, watch } from 'vue';
 import Button from 'primevue/button';
-import { useAppStore } from '../store/app';
 import { useRoute } from 'vue-router';
 import Fieldset from 'primevue/fieldset';
 import FormPropertiesSection from './FormPropertiesSection.vue';
@@ -15,10 +14,9 @@ const dialogRef: any = inject('dialogRef');
 
 const emit = defineEmits<{
   (e: 'close'): void;
-  (e: 'created'): void;
+  (e: 'create'): void;
 }>();
 
-const { addToastMessage } = useAppStore();
 const { getAnnotationConfig, getAnnotationFields } = useGuidelinesStore();
 
 const annotationToCreate: Annotation = dialogRef.value.data.annotation;
@@ -30,52 +28,44 @@ const propertyFields: PropertyConfig[] = getAnnotationFields(
 const asyncOperationRunning = ref<boolean>(false);
 const propertiesAreCollapsed = ref<boolean>(false);
 
+const inputIsValid = computed<boolean>(checkAnnotationValidity);
+
 watch(() => route.path, closeModal);
 
-// function closeModal(): void {
-//   emit('close');
-// }
+// TODO: Move this to helper or something
+function checkAnnotationValidity() {
+  // For properties. Will be extended when rules for connected entites etc. are applied
+  return propertyFields.every((field: PropertyConfig) => {
+    if (!field.required) {
+      return true;
+    }
+
+    const value = annotationToCreate.data.properties[field.name];
+
+    if (value === null || value === undefined) {
+      return false;
+    }
+
+    if (field.type === 'string' && value.trim().length === 0) {
+      return false;
+    }
+
+    return true;
+  });
+}
 
 function closeModal(): void {
   dialogRef.value.close();
 }
 
-// function showMessage(result: 'success' | 'error', error?: Error) {
-//   addToastMessage({
-//     severity: result,
-//     summary: result === 'success' ? 'Changes saved successfully' : 'Error saving changes',
-//     detail: error?.message ?? '',
-//     life: 2000,
-//   });
-// }
-// const isMounted = computed(() => {
-//   if (annotationToCreate.value !== null) {
-//     console.log('exists');
-//     return true;
-//   } else {
-//     console.log('DOJES NOT EXIST');
-//     return false;
-//   }
-// });
-
 function handleCancelClick(): void {
   closeModal();
 }
 
-async function handleSubmitClick(): Promise<void> {
-  asyncOperationRunning.value = true;
+function handleSubmitClick(): void {
+  closeModal();
 
-  try {
-    // await api.deleteCollection(collection.value.collection.data.uuid);
-
-    closeModal();
-
-    emit('created');
-  } catch (error: unknown) {
-    // showMessage('error', error as Error);
-  } finally {
-    asyncOperationRunning.value = false;
-  }
+  emit('create');
 }
 </script>
 
@@ -121,6 +111,7 @@ async function handleSubmitClick(): Promise<void> {
 
   <div class="button-container flex justify-content-end gap-2">
     <Button
+      :disabled="!inputIsValid"
       type="submit"
       label="Create"
       severity="success"
@@ -137,4 +128,8 @@ async function handleSubmitClick(): Promise<void> {
   </div>
 </template>
 
-<style scoped></style>
+<style scoped>
+.content {
+  overflow-y: scroll;
+}
+</style>

--- a/client/src/components/AnnotationCreateModal.vue
+++ b/client/src/components/AnnotationCreateModal.vue
@@ -6,7 +6,7 @@ import Fieldset from 'primevue/fieldset';
 import FormPropertiesSection from './FormPropertiesSection.vue';
 import AnnotationFormAdditionalTextSection from './AnnotationFormAdditionalTextSection.vue';
 import AnnotationFormEntitiesSection from './AnnotationFormEntitiesSection.vue';
-import { Annotation, AnnotationType, PropertyConfig } from '../models/types';
+import { AnnotationData, AnnotationType, PropertyConfig } from '../models/types';
 import { useGuidelinesStore } from '../store/guidelines';
 
 const route = useRoute();
@@ -14,16 +14,14 @@ const dialogRef: any = inject('dialogRef');
 
 const emit = defineEmits<{
   (e: 'close'): void;
-  (e: 'create'): void;
+  (e: 'submit', annotation: AnnotationData): void;
 }>();
 
 const { getAnnotationConfig, getAnnotationFields } = useGuidelinesStore();
 
-const annotationToCreate: Annotation = dialogRef.value.data.annotation;
-const config: AnnotationType = getAnnotationConfig(annotationToCreate.data.properties.type);
-const propertyFields: PropertyConfig[] = getAnnotationFields(
-  annotationToCreate.data.properties.type,
-);
+const annotationTemplate: AnnotationData = dialogRef.value.data.annotation;
+const config: AnnotationType = getAnnotationConfig(annotationTemplate.properties.type);
+const propertyFields: PropertyConfig[] = getAnnotationFields(annotationTemplate.properties.type);
 
 const asyncOperationRunning = ref<boolean>(false);
 const propertiesAreCollapsed = ref<boolean>(false);
@@ -40,7 +38,7 @@ function checkAnnotationValidity() {
       return true;
     }
 
-    const value = annotationToCreate.data.properties[field.name];
+    const value = annotationTemplate.properties[field.name];
 
     if (value === null || value === undefined) {
       return false;
@@ -65,71 +63,81 @@ function handleCancelClick(): void {
 function handleSubmitClick(): void {
   closeModal();
 
-  emit('create');
+  emit('submit', annotationTemplate);
 }
 </script>
 
 <template>
-  <h2 class="w-full text-center m-0">
-    Create new
-    <span class="font-italic">{{ annotationToCreate.data.properties.type }}</span> Annotation
-  </h2>
+  <div class="container flex flex-column">
+    <h2 class="w-full m-0 text-center">
+      Add new <span class="font-italic">{{ annotationTemplate.properties.type }}</span> Annotation
+    </h2>
 
-  <div class="content text-center mb-2" v-if="annotationToCreate">
-    <Fieldset
-      legend="Properties"
-      :toggle-button-props="{
-        title: `${propertiesAreCollapsed ? 'Expand' : 'Collapse'} properties`,
-      }"
-      :toggleable="true"
-      @toggle="propertiesAreCollapsed = !propertiesAreCollapsed"
-    >
-      <template #toggleicon>
-        <span :class="`pi pi-chevron-${propertiesAreCollapsed ? 'down' : 'up'}`"></span>
-      </template>
-      <FormPropertiesSection
-        v-model="annotationToCreate.data.properties"
-        :fields="propertyFields"
+    <div class="content mb-2" v-if="annotationTemplate">
+      <Fieldset
+        legend="Properties"
+        :toggle-button-props="{
+          title: `${propertiesAreCollapsed ? 'Expand' : 'Collapse'} properties`,
+        }"
+        :toggleable="true"
+        @toggle="propertiesAreCollapsed = !propertiesAreCollapsed"
+      >
+        <template #toggleicon>
+          <span :class="`pi pi-chevron-${propertiesAreCollapsed ? 'down' : 'up'}`"></span>
+        </template>
+        <FormPropertiesSection
+          v-model="annotationTemplate.properties"
+          :fields="propertyFields"
+          mode="edit"
+        />
+      </Fieldset>
+      <AnnotationFormAdditionalTextSection
+        v-if="config.hasAdditionalTexts === true"
+        v-model="annotationTemplate.additionalTexts"
+        :initial-additional-texts="[]"
         mode="edit"
       />
-    </Fieldset>
-    <AnnotationFormAdditionalTextSection
-      v-if="config.hasAdditionalTexts === true"
-      v-model="annotationToCreate.data.additionalTexts"
-      :initial-additional-texts="annotationToCreate.initialData.additionalTexts"
-      mode="edit"
-    />
-    <AnnotationFormEntitiesSection
-      v-if="config.hasEntities === true"
-      v-model="annotationToCreate.data.entities"
-      mode="edit"
-      :annotation-config="config"
-      :default-search-value="annotationToCreate.data.properties.text"
-      :initialEntities="annotationToCreate.initialData.entities"
-    />
-  </div>
+      <AnnotationFormEntitiesSection
+        v-if="config.hasEntities === true"
+        v-model="annotationTemplate.entities"
+        mode="edit"
+        :annotation-config="config"
+        :default-search-value="annotationTemplate.properties.text"
+        :initialEntities="[]"
+      />
+    </div>
 
-  <div class="button-container flex justify-content-end gap-2">
-    <Button
-      :disabled="!inputIsValid"
-      type="submit"
-      label="Create"
-      severity="success"
-      :loading="asyncOperationRunning"
-      @click="handleSubmitClick"
-    ></Button>
-    <Button
-      type="button"
-      label="Cancel"
-      title="Cancel"
-      severity="secondary"
-      @click="handleCancelClick"
-    ></Button>
+    <div class="footer flex justify-content-center gap-2">
+      <Button
+        type="button"
+        label="Cancel"
+        icon="pi pi-times"
+        title="Cancel"
+        severity="secondary"
+        @click="handleCancelClick"
+      ></Button>
+      <Button
+        :disabled="!inputIsValid"
+        type="submit"
+        icon="pi pi-plus"
+        label="Add"
+        title="Add annotation"
+        severity="primary"
+        :loading="asyncOperationRunning"
+        @click="handleSubmitClick"
+      ></Button>
+    </div>
   </div>
 </template>
 
 <style scoped>
+.container {
+  height: 100%;
+}
+
 .content {
-  overflow-y: scroll;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  flex-grow: 1;
 }
 </style>

--- a/client/src/components/EditorAnnotationButtonPane.vue
+++ b/client/src/components/EditorAnnotationButtonPane.vue
@@ -14,7 +14,8 @@ import { useValidateTextSelection } from '../composables/useValidateTextSelectio
 import { useDialog } from 'primevue';
 import AnnotationCreateModal from './AnnotationCreateModal.vue';
 
-const { groupedAnnotationTypes, getAnnotationConfig } = useGuidelinesStore();
+const { groupedAnnotationTypes, annotationHasConstraints, getAnnotationConfig } =
+  useGuidelinesStore();
 const { addToastMessage, createModalInstance, destroyModalInstance } = useAppStore();
 const { execCommand } = useEditorStore();
 const { getCharactersInSelection } = useCharactersStore();
@@ -50,20 +51,20 @@ function handleClick(data: { type: string; subType?: string | number }) {
     const selectedCharacters: Character[] = getCharactersInSelection();
     const newAnnotation: Annotation = createAnnotation({ ...data, characters: selectedCharacters });
 
-    if (config.hasEntities === true) {
+    if (annotationHasConstraints(config)) {
       createModalInstance(
         dialog.open(AnnotationCreateModal, {
           props: {
             modal: true,
             closable: false,
-            closeOnEscape: false,
+            closeOnEscape: true,
             style: { width: '25rem' },
           },
           data: {
             annotation: newAnnotation,
           },
           emits: {
-            onCreated: () => {
+            onCreate: () => {
               execCommand('createAnnotation', {
                 annotation: newAnnotation,
                 characters: selectedCharacters,

--- a/client/src/components/EditorAnnotationButtonPane.vue
+++ b/client/src/components/EditorAnnotationButtonPane.vue
@@ -2,7 +2,7 @@
 import { useGuidelinesStore } from '../store/guidelines';
 import { capitalize } from '../utils/helper/helper';
 import AnnotationButton from './AnnotationButton.vue';
-import { Annotation, AnnotationType, Character } from '../models/types';
+import { Annotation, AnnotationData, AnnotationType, Character } from '../models/types';
 import { useCharactersStore } from '../store/characters';
 import { useCreateAnnotation } from '../composables/useCreateAnnotation';
 import { useEditorStore } from '../store/editor';
@@ -49,7 +49,10 @@ function handleClick(data: { type: string; subType?: string | number }) {
     isSelectionValid(config);
 
     const selectedCharacters: Character[] = getCharactersInSelection();
-    const newAnnotation: Annotation = createAnnotation({ ...data, characters: selectedCharacters });
+    const newAnnotationTemplate: Annotation = createAnnotation({
+      ...data,
+      characters: selectedCharacters,
+    });
 
     if (annotationHasConstraints(config)) {
       createModalInstance(
@@ -58,18 +61,28 @@ function handleClick(data: { type: string; subType?: string | number }) {
             modal: true,
             closable: false,
             closeOnEscape: true,
-            style: { width: '25rem' },
+            dismissableMask: true,
+            style: { width: '25rem', height: '35rem' },
+            pt: {
+              content: {
+                style: {
+                  flexGrow: 1,
+                },
+              },
+            },
           },
           data: {
-            annotation: newAnnotation,
+            annotation: newAnnotationTemplate.data,
           },
           emits: {
-            onCreate: () => {
-              execCommand('createAnnotation', {
-                annotation: newAnnotation,
+            onSubmit: (editedAnnotationData: AnnotationData) => {
+              addAnnotationToStore({
+                annotation: {
+                  ...newAnnotationTemplate,
+                  data: editedAnnotationData,
+                },
                 characters: selectedCharacters,
               });
-
               destroyModalInstance();
             },
           },
@@ -77,10 +90,7 @@ function handleClick(data: { type: string; subType?: string | number }) {
         }),
       );
     } else {
-      execCommand('createAnnotation', {
-        annotation: newAnnotation,
-        characters: selectedCharacters,
-      });
+      addAnnotationToStore({ annotation: newAnnotationTemplate, characters: selectedCharacters });
     }
   } catch (error: unknown) {
     if (error instanceof AnnotationRangeError) {
@@ -101,6 +111,21 @@ function handleClick(data: { type: string; subType?: string | number }) {
       console.error('Unexpected error:', error);
     }
   }
+}
+
+/**
+ * Adds a new annotation to the store by executing the `createAnnotation` command.
+ *
+ * @param {Object} params - Object with two properties: `annotation` and `characters`.
+ * @param {Annotation} params.annotation - The annotation to add to the store.
+ * @param {Character[]} params.characters - The characters associated with the annotation.
+ * @returns {void} This function does not return any value.
+ */
+function addAnnotationToStore(params: { annotation: Annotation; characters: Character[] }): void {
+  execCommand('createAnnotation', {
+    annotation: params.annotation,
+    characters: params.characters,
+  });
 }
 </script>
 

--- a/client/src/components/EditorAnnotationButtonPane.vue
+++ b/client/src/components/EditorAnnotationButtonPane.vue
@@ -11,14 +11,18 @@ import ShortcutError from '../utils/errors/shortcut.error';
 import AnnotationRangeError from '../utils/errors/annotationRange.error';
 import { useAppStore } from '../store/app';
 import { useValidateTextSelection } from '../composables/useValidateTextSelection';
+import { useDialog } from 'primevue';
+import AnnotationCreateModal from './AnnotationCreateModal.vue';
 
 const { groupedAnnotationTypes, getAnnotationConfig } = useGuidelinesStore();
-const { addToastMessage } = useAppStore();
+const { addToastMessage, createModalInstance, destroyModalInstance } = useAppStore();
 const { execCommand } = useEditorStore();
 const { getCharactersInSelection } = useCharactersStore();
 const { selectedOptions } = useFilterStore();
 const { createTextAnnotation: createAnnotation } = useCreateAnnotation('Text');
 const { isValid: isSelectionValid } = useValidateTextSelection();
+
+const dialog: ReturnType<typeof useDialog> = useDialog();
 
 /**
  * Checks if the annotation type is enabled by verifying if it is included in the selected options. If not, an `ShortcutError` is thrown.
@@ -46,10 +50,37 @@ function handleClick(data: { type: string; subType?: string | number }) {
     const selectedCharacters: Character[] = getCharactersInSelection();
     const newAnnotation: Annotation = createAnnotation({ ...data, characters: selectedCharacters });
 
-    execCommand('createAnnotation', {
-      annotation: newAnnotation,
-      characters: selectedCharacters,
-    });
+    if (config.hasEntities === true) {
+      createModalInstance(
+        dialog.open(AnnotationCreateModal, {
+          props: {
+            modal: true,
+            closable: false,
+            closeOnEscape: false,
+            style: { width: '25rem' },
+          },
+          data: {
+            annotation: newAnnotation,
+          },
+          emits: {
+            onCreated: () => {
+              execCommand('createAnnotation', {
+                annotation: newAnnotation,
+                characters: selectedCharacters,
+              });
+
+              destroyModalInstance();
+            },
+          },
+          onClose: destroyModalInstance,
+        }),
+      );
+    } else {
+      execCommand('createAnnotation', {
+        annotation: newAnnotation,
+        characters: selectedCharacters,
+      });
+    }
   } catch (error: unknown) {
     if (error instanceof AnnotationRangeError) {
       addToastMessage({

--- a/client/src/store/guidelines.ts
+++ b/client/src/store/guidelines.ts
@@ -35,6 +35,27 @@ export function useGuidelinesStore() {
   }
 
   /**
+   * Checks if an annotation type has constraints such as required properties, entities etc.
+   *
+   * Currently used for when the user clicks on an annotation button to enforce constraints.
+   *
+   * @param {AnnotationType} config The annotation type to check.
+   * @returns {boolean} True if the annotation type has constraints.
+   */
+  function annotationHasConstraints(config: AnnotationType): boolean {
+    // TODO: The subType field requires a lot of hacks -> Refactor later
+    if (config.properties?.some(p => p.required === true && p.name !== 'subType')) {
+      return true;
+    }
+
+    if (config.hasEntities === true) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
    * Retrieves the configuration for an annotation of given type. The configuration is an object containing internal information
    * as well as information about rendering behaviour (input type in forms, selection status etc.).
    *
@@ -273,6 +294,7 @@ export function useGuidelinesStore() {
     guidelines,
     isFetching: readonly(isFetching),
     isInitialized: readonly(isInitialized),
+    annotationHasConstraints,
     getAllCollectionConfigFields,
     getAnnotationConfig,
     getAnnotationFields,


### PR DESCRIPTION
When a new text annotation should be added in the editor (via button click or shortcut), a modal is shown when there are required properties and/or entities can be connected to the annotation (persons, places, event. etc.). This is done to reduce clicks as well as force the user to fill in data.

Key changes:
- Added modal that is shown when an annotation with constraints is about to be created
- Added constraint checking functionality to guidelines store